### PR TITLE
Regex named_captures in Ruby 1.9.2

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -50,7 +50,7 @@ JS
 
 
     def build_params route
-      route.conditions[:path_info].captures.map do |cap|
+      route.conditions[:path_info].named_captures.map do |cap|
         if cap.is_a?(Rack::Mount::GeneratableRegexp::DynamicSegment) && !(cap.name.to_s == "format")
           cap.name.to_s.gsub(/^:/, '')
         end


### PR DESCRIPTION
Hi,

I couldn't get your gem to run in Ruby 1.9.2 out of the box. I needed to change captures to named_captures on line 53 of js_routes.rb.

All of the specs are now running clean in Ruby 1.8.7 and Ruby 1.9.2. They did not run at all before in 1.9.2.

Thanks for the nice gem!
