### PR TITLE
Add prefix support.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,12 +30,15 @@ Available options:
   * Note that regexp applied to **named route** not to *URL*
 * `:namespace` - global object used to access routes. Default: `Routes`
   * Supports nested namespace like `MyProject.routes`
+* `:prefix` - String representing a url path to prepend to all paths
+  * `Should be specified via :prefix => "/myprefix"`
 
 Example options usage:
 
 ``` ruby
 JsRoutes.generate!(:file => "#{path}/app_routes.js", :namespace => "AppRoutes", :exclude => /^admin_/, :default_format => "json")
 JsRoutes.generate!(:file => "#{path}/adm_routes.js", :namespace => "AdmRoutes", :include => /^admin_/, :default_format => "json")
+JsRoutes.generate!(:file => "#{path}/app_routes.js", :namespace => "AppRoutes", :exclude => /^admin_/, :default_format => "json", :prefix => ENV['RAILS_RELATIVE_URL_ROOT'])
 ```
 
 In order to generate routes to string and manipulate them yourself use:

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -24,6 +24,7 @@ class JsRoutes
     js = File.read(File.dirname(__FILE__) + "/routes.js")
     js.gsub!("NAMESPACE", @options[:namespace])
     js.gsub!("DEFAULT_FORMAT", @options[:default_format].to_s)
+    js.gsub!("PREFIX", @options[:prefix])
     js.gsub!("ROUTES", js_routes)
   end
 
@@ -90,6 +91,7 @@ class JsRoutes
       :exclude => [],
       :include => //,
       :file => default_file,
+      :prefix => ""
     }
   end
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,7 @@
   var Utils = {
 
     default_format: 'DEFAULT_FORMAT',
+    prefix: 'PREFIX',
 
     serialize: function(obj){
       if (obj === null) {return '';}
@@ -47,7 +48,7 @@
 
     build_path: function(number_of_params, parts, args) {
       args = Array.prototype.slice.call(args);
-      result = "";
+      result = Utils.get_prefix();
       var opts = Utils.extract_options(number_of_params, args);
       for (var i=0; i < parts.length; i++) {
         value = args.shift();
@@ -71,6 +72,16 @@
 
     optional_part: function(part) {
       return part.match(/\(/);
+    },
+
+    get_prefix: function(){
+      var prefix = Utils.prefix;
+
+      if( prefix !== "" ){
+        prefix = prefix.match('\/$') ? prefix : ( prefix + '/');
+      }
+      
+      return prefix;
     }
 
   };

--- a/spec/js_routes_spec.rb
+++ b/spec/js_routes_spec.rb
@@ -66,6 +66,26 @@ describe JsRoutes do
     end
   end
 
+  context "when prefix with trailing slash is specified" do
+    
+    let(:_options) { {:prefix => "/myprefix/" } }
+
+    it "should render routing with prefix" do
+        evaljs("Routes.inbox_path(1)").should == "/myprefix/inboxes/1"
+    end
+
+  end
+  
+  context "when prefix without trailing slash is specified" do
+    
+    let(:_options) { {:prefix => "/myprefix" } }
+
+    it "should render routing with prefix" do
+        evaljs("Routes.inbox_path(1)").should == "/myprefix/inboxes/1"
+    end
+
+  end
+
   context "when default_format is specified" do
     let(:_options) { {:default_format => "json"} }
     
@@ -73,7 +93,7 @@ describe JsRoutes do
       evaljs("Routes.inbox_path(1)").should == "/inboxes/1.json"
     end
 
-    it "should override default_format wehn spefified implicitly" do
+    it "should override default_format when spefified implicitly" do
       evaljs("Routes.inbox_path(1, {format: 'xml'})").should == "/inboxes/1.xml"
     end
 


### PR DESCRIPTION
Designed to add support for setting a prefix URL for all paths.  This is particularly in response to the ability to specify a URL prefix when using the Thin appserver.
