### PR TITLE
Add JavaScript function to set prefix dynamically

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,7 @@ Routes.company_path(google) // => "/companies/google"
 Setting the prefix in JavaScript
 
 ``` js
-Routes.set_prefix('/myprefix');
+Routes.options.prefix = '/myprefix';
 ```
 
 In order to make routes helpers available globally:

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -2,9 +2,6 @@
 
   var Utils = {
 
-    default_format: 'DEFAULT_FORMAT',
-    prefix: 'PREFIX',
-
     serialize: function(obj){
       if (obj === null) {return '';}
       var s = [];
@@ -22,7 +19,7 @@
     },
 
     extract_format: function(options) {
-      var format =  options.hasOwnProperty("format") ? options.format : Utils.default_format;
+      var format =  options.hasOwnProperty("format") ? options.format : window.NAMESPACE.options.default_format;
       delete options.format;
       return format ? "." + format : "";
     },
@@ -75,7 +72,7 @@
     },
 
     get_prefix: function(){
-      var prefix = Utils.prefix;
+      var prefix = window.NAMESPACE.options.prefix;
 
       if( prefix !== "" ){
         prefix = prefix.match('\/$') ? prefix : ( prefix + '/');
@@ -88,8 +85,9 @@
 
   window.NAMESPACE = ROUTES;
   
-  window.NAMESPACE.set_prefix = function(prefix){
-    Utils.prefix = prefix;
+  window.NAMESPACE.options = {
+    prefix: 'PREFIX',
+    default_format: 'DEFAULT_FORMAT',
   };
 
 

--- a/spec/js_routes_spec.rb
+++ b/spec/js_routes_spec.rb
@@ -75,7 +75,7 @@ describe JsRoutes do
     end
 
     it "should render routing with prefix set in JavaScript" do
-      evaljs("Routes.set_prefix('/newprefix/')")
+      evaljs("Routes.options.prefix = '/newprefix/'")
       evaljs("Routes.inbox_path(1)").should == "/newprefix/inboxes/1"
     end
 
@@ -90,7 +90,7 @@ describe JsRoutes do
     end
     
     it "should render routing with prefix set in JavaScript" do
-      evaljs("Routes.set_prefix('/newprefix')")
+      evaljs("Routes.options.prefix = '/newprefix'")
       evaljs("Routes.inbox_path(1)").should == "/newprefix/inboxes/1"
     end
 


### PR DESCRIPTION
After some review, setting the prefix at routes generation time does not fit with all build and deployment models. I wanted to add a way to be able to set the prefix dynamically via JavaScript with a pre-generated routes.js file.

Check routes.js for the majority of the changes. Spec tests to cover new functionality were also added. Readme updated as well.

Moves prefix and default_format onto Routes.options object and changes Utils functions to reference those values.
