### PR TITLE
Fix engine when running under production with config.assets.compile set true

### DIFF
--- a/lib/js_routes/engine.rb
+++ b/lib/js_routes/engine.rb
@@ -10,12 +10,6 @@ if defined?(Rails) && Rails.version >= "3.1"
           data
         end
       end
-
-      initializer 'js-routes.setup', :group => :all do |app|
-        # load up the js-routes configuration file (should one exist)
-        config_file = Rails.root.join('config','js-routes.rb')
-        JsRoutes.instance_eval(IO.read(config_file)) if File.exist?(config_file)
-      end
     end
   end
 end


### PR DESCRIPTION
Reworked the initializer logic so it fires in the correct place under the production environment when config.assets.compile flag is set to true.
