### PR TITLE
Assert that the environment is initialized under rails 3.1.1.rc3 and up

### DIFF
--- a/app/assets/javascripts/js-routes.js.erb
+++ b/app/assets/javascripts/js-routes.js.erb
@@ -1,1 +1,1 @@
-<%= JsRoutes.generate %>
+<%= JsRoutes.assert_usable_configuration! && JsRoutes.generate %>

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -47,6 +47,15 @@ class JsRoutes
     def generate!(opts = {})
       new(opts).generate!
     end
+
+    # Under rails 3.1.1 and higher, perform a check to ensure that the
+    # full environment will be available during asset compilation.
+    # This is required to ensure routes are loaded.
+    def assert_usable_configuration!
+      @usable_configuration ||= Rails.version >= "3.1.1" && 
+        Rails.application.config.assets.initialize_on_precompile ||
+        raise("Cannot precompile js-routes unless environment is initialized. Please set config.assets.initialize_on_precompile to true.")
+    end
   end
 
   #


### PR DESCRIPTION
Please note: this patch does not function correctly under rc2, but makes use of additional flags added in rails 3-1-stable which will be part of 3.1.1.rc3 and/or final.

This patch adds an assertion call to the js.erb file which will ensure that the configuration is suitable for including the js.erb file.  Users are informed that they should toggle the config.assets.initialize_on_precompile flag to true - their other option is to roll their own jsroutes file, presumably via the generator route, rather than relying on the engine.
