### PR TITLE
fix include/exclude on rails3.1.0

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -81,7 +81,7 @@ class JsRoutes
   def js_routes
     Rails.application.reload_routes!
     js_routes = Rails.application.routes.named_routes.routes.map do |_, route|
-      if any_match?(route, @options[:exclude]) || !any_match?(route, @options[:include])
+      if any_match?(route, @options[:exclude]) ^ any_match?(route, @options[:include])
         nil
       else
         build_js(route)


### PR DESCRIPTION
Honestly, i haven't tested it on other versions, but it seems to be a bug into routes filtering:
If i want to exclude everything except included like:

```
:include => [/^foo/, /^bar/], :exclude => //,
```

but i get no routes.

Patch applied.
