### PR TITLE
Fix for js-routes in asset pipeline

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -52,9 +52,10 @@ class JsRoutes
     # full environment will be available during asset compilation.
     # This is required to ensure routes are loaded.
     def assert_usable_configuration!
-      unless @usable_configuration ||= Rails.version <= "3.1.0" || Rails.application.config.assets.initialize_on_precompile
+      if Rails.version > "3.1.0" && !Rails.application.config.assets.initialize_on_precompile 
         raise("Cannot precompile js-routes unless environment is initialized. Please set config.assets.initialize_on_precompile to true.")
       end
+      true
     end
   end
 

--- a/spec/post_rails_init_spec.rb
+++ b/spec/post_rails_init_spec.rb
@@ -53,6 +53,40 @@ describe "after Rails initialization" do
             ctx.should_receive(:depend_on).with(Rails.root.join('config','routes.rb'))
             ctx.evaluate('js-routes.js')
           end
+
+          context 'with Rails 3.1.0' do
+            it "should render some javascript" do
+              Rails.stub!("version").and_return "3.1.0"
+              Rails.application.config.assets.initialize_on_precompile = false
+
+              ctx = Sprockets::Context.new(Rails.application.assets,
+                                           'js-routes.js',
+                                           Pathname.new('js-routes.js'))
+              ctx.evaluate('js-routes.js').should =~ /window\.Routes/
+            end
+          end
+
+          context "with Rails 3.1.1" do
+            it "should render some javascript when initialize_on_precompile is true" do
+              Rails.stub!("version").and_return "3.1.1"
+              Rails.application.config.assets.initialize_on_precompile = true
+
+              ctx = Sprockets::Context.new(Rails.application.assets,
+                                           'js-routes.js',
+                                           Pathname.new('js-routes.js'))
+              ctx.evaluate('js-routes.js').should =~ /window\.Routes/
+            end
+
+            it "should raise an exception when initialize_on_precompile is false" do
+              Rails.stub!("version").and_return "3.1.1"
+              Rails.application.config.assets.initialize_on_precompile = false
+
+              ctx = Sprockets::Context.new(Rails.application.assets,
+                                           'js-routes.js',
+                                           Pathname.new('js-routes.js'))
+              lambda { ctx.evaluate('js-routes.js') }.should raise_error(/Cannot precompile/)
+            end
+          end
         end
 
         context "when not dealing with js-routes.js" do


### PR DESCRIPTION
The js-routes.js.erb file is currently written to only generate the js routes if the  JsRoutes.assert_usable_configuration! method returns true. That method raises an exception when Rails isn't configured properly. But it was returning nil when it didn't raise an exception.

I changed the method to return true when no exception is raised.

I made some attempts to test my changes. I had to remove a memoizing member variable (@usable_configuration) from the assert_usable_configuration! implementation though. It would remember the config values from the first test that is run, making it impossible to properly test other scenarios.
