### PR TITLE
Fix require in less:js:routes task

### DIFF
--- a/lib/tasks/js_routes.rake
+++ b/lib/tasks/js_routes.rake
@@ -1,9 +1,8 @@
-
 namespace :less do
   namespace :js do
     desc "Make a js file that will have functions that will return restful routes/urls."
     task :routes => :environment do
-      require "jsroutes"
+      require "js-routes"
 
       # Hack for actually load the routes (taken from railties console/app.rb)
       ActionDispatch::Callbacks.new(lambda {}, false)


### PR DESCRIPTION
$ rake less:js:routes
rake aborted!
no such file to load -- jsroutes

Tasks: TOP => less:js:routes
(See full trace by running task with --trace)
