### PR TITLE
Array as parameter in URL

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -12,7 +12,14 @@
       var s = [];
       for (prop in obj){
         if (obj[prop]) {
-          s.push(prop + "=" + encodeURIComponent(obj[prop].toString()));
+          if (obj[prop] instanceof Array) {
+            for (var i=0; i < obj[prop].length; i++) {
+              key = prop + encodeURIComponent("[]");
+              s.push(key + "=" + encodeURIComponent(obj[prop][i].toString()));
+            }
+          } else {
+            s.push(prop + "=" + encodeURIComponent(obj[prop].toString()));
+          }
         }
       }
       if (s.length === 0) {

--- a/spec/js_routes_spec.rb
+++ b/spec/js_routes_spec.rb
@@ -36,8 +36,12 @@ describe JsRoutes do
       evaljs("Routes.inbox_path(1, {format: 'json'})").should == routes.inbox_path(1, :format => "json")
     end
 
-    it "should support get parameters" do
+    it "should support simple get parameters" do
       evaljs("Routes.inbox_path(1, {format: 'json', lang: 'ua', q: 'hello'})").should == routes.inbox_path(1, :lang => "ua", :q => "hello", :format => "json")
+    end
+
+    it "should support array get parameters" do
+      evaljs("Routes.inbox_path(1, {hello: ['world', 'mars']})").should == routes.inbox_path(1, :hello => [:world, :mars])
     end
 
     it "should support null and undefined parameters" do


### PR DESCRIPTION
Small fix.

Support array as URL parameter.

@bogdan
Do you think I should update README and include an example into `Usage` section?
