### PR TITLE
Allowing to pass no argument to generate! (#39)

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -92,7 +92,7 @@ class JsRoutes
     js.gsub!("ROUTES", js_routes)
   end
 
-  def generate!(file_name)
+  def generate!(file_name = nil)
     # Some libraries like Devise do not yet loaded their routes so we will wait
     # until initialization process finish
     # https://github.com/railsware/js-routes/issues/7


### PR DESCRIPTION
Here is a small modification of the `generate!` method. It know accepts to receive no argument.

This makes sense since the code do `file_name || DEFAULT_PATH`.
