### PR TITLE
Allowing to pass no argument to JsRoutes::generate! (#39)

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -53,7 +53,6 @@ class JsRoutes
     end
 
     def generate!(file_name=nil, opts = {})
-      file_name ||= Rails.root + DEFAULT_PATH
       if file_name.is_a?(Hash)
         opts = file_name
         file_name = opts[:file]
@@ -98,6 +97,7 @@ class JsRoutes
     # until initialization process finish
     # https://github.com/railsware/js-routes/issues/7
     Rails.configuration.after_initialize do
+      file_name ||= self.class.options['file']
       File.open(Rails.root.join(file_name || DEFAULT_PATH), 'w') do |f|
         f.write generate
       end


### PR DESCRIPTION
Ok, same as previous commit but for `JsRoutes::generate!`.
This time it's working correctly with the rake task.
