### PR TITLE
Added full URLs support

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -12,7 +12,8 @@ class JsRoutes
     :exclude => [],
     :include => //,
     :file => DEFAULT_PATH,
-    :prefix => ""
+    :prefix => "",
+    :host => ""
   }
 
   # We encode node symbols as integer to reduce the routes.js file size
@@ -88,6 +89,7 @@ class JsRoutes
     js.gsub!("NAMESPACE", @options[:namespace])
     js.gsub!("DEFAULT_FORMAT", @options[:default_format].to_s)
     js.gsub!("PREFIX", @options[:prefix])
+    js.gsub!("HOST", @options[:host])
     js.gsub!("NODE_TYPES", json(NODE_TYPES))
     js.gsub!("ROUTES", js_routes)
   end
@@ -144,6 +146,9 @@ class JsRoutes
   // #{name.join('.')} => #{parent_spec}#{route.path.spec}
   #{name.join('_')}_path: function(#{build_params(required_parts)}) {
   return Utils.build_path(#{json(required_parts)}, #{json(optional_parts)}, #{json(serialize(route.path.spec, parent_spec))}, arguments);
+  },
+  #{name.join('_')}_url: function(#{build_params(required_parts)}) {
+  return Utils.build_url(#{json(required_parts)}, #{json(optional_parts)}, #{json(serialize(route.path.spec, parent_spec))}, arguments);
   }
   JS
   end

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -6,6 +6,7 @@
   ParameterMissing.prototype = new Error(); 
 
   var defaults = {
+    host: 'HOST',
     prefix: 'PREFIX',
     format: 'DEFAULT_FORMAT'
   };
@@ -121,6 +122,10 @@
       return Utils.clean_path(result + anchor) + Utils.serialize(parameters);
     },
 
+    build_url: function(required_parameters, optional_parts, route, args) {
+      return Utils.get_host() + Utils.build_path(required_parameters, optional_parts, route, args);
+    },
+
     /*
      * This function is JavaScript impelementation of the
      * Journey::Visitors::Formatter that builds route by given parameters
@@ -184,6 +189,16 @@
       }
       
       return prefix;
+    },
+
+    get_host: function(){
+      var host = defaults.host;
+
+      if( host !== "" ){
+        host = host.match('\/$') ? host.substr(0,host.length-1) : host;
+      }
+      
+      return host;
     },
 
     namespace: function (root, namespaceString) {


### PR DESCRIPTION
I needed a way to provide full URLs in my API files, that are distributed to other people.
So I added a `:host` option to js-routes config and `_url` route helpers.
Feel free to integrate my work in yours.

Yann
