### PR TITLE
Replace exception throwing by flag passing in recursive calls

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -133,9 +133,9 @@
      * Binary tree is serialized in the following way:
      * [node type, left node, right node ]
      *
-     *@param  {Boolean} silent  If set to `true`, this method will not throw when encountering a missing parameter (used in recursive calls).
+     *@param  {Boolean} optional  Marks the currently visited branch as optional. If set to `true`, this method will not throw when encountering a missing parameter (used in recursive calls).
      */
-    visit: function(route, options, silent) {
+    visit: function(route, options, optional) {
       var type = route[0];
       var left = route[1];
       var right = route[2];
@@ -145,10 +145,10 @@
         case NodeTypes.STAR:
           return this.visit(left, options, true)
         case NodeTypes.CAT:
-          var leftPart = this.visit(left, options, silent),
-              rightPart = this.visit(right, options, silent);
+          var leftPart = this.visit(left, options, optional),
+              rightPart = this.visit(right, options, optional);
 
-          if (silent && ! (leftPart && rightPart))
+          if (optional && ! (leftPart && rightPart))
             return '';
 
           return leftPart + rightPart;
@@ -166,7 +166,7 @@
             return this.path_identifier(value);
           }
 
-          if (silent) {
+          if (optional) {
             return '';  // missing parameter
           } else {
             throw new ParameterMissing("Route parameter missing: " + left);


### PR DESCRIPTION
The main method for routes resolution, `visit`, relied on throwing a `ParameterMissing` exception whenever it… well, had a missing parameter  ;)

While, in cases where the user explicitly forgot adding a mandatory parameter, this was (and still is) desirable, this same behavior was used as a way to handle optional parts of a route through a `catch` logic.

This raised two issues. The first was an annoying behavior of breaking flow whenever code was debugged on the frontend. The second was one of performance. Exceptions are costly, `try-catch` blocks are costly, and the use of a helper method to handle the cases in which exceptions were there to handle logic prevented tail recursion optimization.

This implementation relies on a “sticky” (i.e. recursively passed) flag to decide whether an exception should be thrown or not (i.e. whether the caller expects the missing parameter to be part of the resolution logic or not).

No tests had to be added since the result was expected to be fully isofunctional to the original implementation, and no tests could be added since this implementation detail could not be tested without injecting global code that would detect caught exceptions, and that would be quite costly (the only solution I have at first sight would be to augment `Error` prototype and detect calls to its constructor, which I don't have the necessary knowledge for at the moment).
