### PR TITLE
Don't append null parameters to generated paths

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -17,13 +17,20 @@
 
   Utils = {
     serialize: function(obj) {
-      var i, key, prop, result, s, val, _i, _len;
+      var has_values, i, key, prop, result, s, val, _i, _len;
+
       if (!obj) {
         return "";
       }
       if (window.jQuery) {
+        has_values = false;
+        for (key in obj) {
+          if (obj[key]) {
+            has_values = true;
+          }
+        }
         result = window.jQuery.param(obj);
-        return (!result ? "" : "?" + result);
+        return (has_values && result ? "?" + result : "");
       }
       s = [];
       for (key in obj) {
@@ -47,6 +54,7 @@
     },
     clean_path: function(path) {
       var last_index;
+
       path = path.split("://");
       last_index = path.length - 1;
       path[last_index] = path[last_index].replace(/\/+/g, "/").replace(/\/$/m, "");
@@ -54,6 +62,7 @@
     },
     set_default_url_options: function(optional_parts, options) {
       var i, part, _i, _len, _results;
+
       _results = [];
       for (i = _i = 0, _len = optional_parts.length; _i < _len; i = ++_i) {
         part = optional_parts[i];
@@ -67,6 +76,7 @@
     },
     extract_anchor: function(options) {
       var anchor;
+
       anchor = "";
       if (options.hasOwnProperty("anchor")) {
         anchor = "#" + options.anchor;
@@ -76,6 +86,7 @@
     },
     extract_options: function(number_of_params, args) {
       var ret_value;
+
       ret_value = {};
       if (args.length > number_of_params && typeof args[args.length - 1] === "object") {
         ret_value = args.pop();
@@ -84,6 +95,7 @@
     },
     path_identifier: function(object) {
       var property;
+
       if (object === 0) {
         return "0";
       }
@@ -101,6 +113,7 @@
     },
     clone: function(obj) {
       var attr, copy, key;
+
       if (null === obj || "object" !== typeof obj) {
         return obj;
       }
@@ -114,6 +127,7 @@
     },
     prepare_parameters: function(required_parameters, actual_parameters, options) {
       var i, result, val, _i, _len;
+
       result = this.clone(options) || {};
       for (i = _i = 0, _len = required_parameters.length; _i < _len; i = ++_i) {
         val = required_parameters[i];
@@ -123,6 +137,7 @@
     },
     build_path: function(required_parameters, optional_parts, route, args) {
       var opts, parameters, result;
+
       args = Array.prototype.slice.call(args);
       opts = this.extract_options(required_parameters.length, args);
       if (args.length > required_parameters.length) {
@@ -135,6 +150,7 @@
     },
     visit: function(route, parameters, optional) {
       var left, left_part, right, right_part, type, value;
+
       type = route[0], left = route[1], right = route[2];
       switch (type) {
         case NodeTypes.GROUP:
@@ -169,6 +185,7 @@
     },
     get_prefix: function() {
       var prefix;
+
       prefix = defaults.prefix;
       if (prefix !== "") {
         prefix = (prefix.match("/$") ? prefix : "" + prefix + "/");
@@ -177,6 +194,7 @@
     },
     namespace: function(root, namespaceString) {
       var current, parts;
+
       parts = (namespaceString ? namespaceString.split(".") : []);
       if (!parts.length) {
         return;

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -9,8 +9,11 @@ Utils =
   serialize: (obj) ->
     return ""  unless obj
     if window.jQuery
+      has_values = false
+      for key of obj
+        has_values = true if obj[key]
       result = window.jQuery.param(obj)
-      return (if not result then "" else "?#{result}")
+      return (if (has_values && result) then "?#{result}" else "")
     s = []
     for own key, prop of obj
       if prop?

--- a/spec/js_routes/rails_routes_compatibility_spec.rb
+++ b/spec/js_routes/rails_routes_compatibility_spec.rb
@@ -112,6 +112,14 @@ describe JsRoutes, "compatibility with Rails"  do
       end
       it_should_behave_like 'serialization'
     end
+    context "when parameters include null value" do
+      let(:_value) do
+        {id: nil}
+      end
+      it "should support routes with parameters" do
+        evaljs("Routes.frood_path(1)").should == routes.frood_path(1)
+      end
+    end
   end
 
   context "using optional path fragments" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,8 @@ def draw_routes
     get '/json_only' => "foo#foo", :format => true, :constraints => {:format => /json/}, :as => :json_only
 
     get '/привет' => "foo#foo", :as => :hello
+
+    get '/froods/:id' => "foo#foo", :as => :frood
   end
 
 end


### PR DESCRIPTION
js-routes was generating routes in my application that looked like `/foo/34?id=`, from a route that looked like `get "/foo/:id" => "foo#bar", as: :foo`

I couldn't replicate that behavior in the js-routes specs until I noticed the `if window.jQuery` section in the serialize function.
