### PR TITLE
Remove unsupported rubies from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - ruby-head


### PR DESCRIPTION
Sorry, forgot about this. 

Remove unsupported rubies from travis tests. Just need tests 1.9.3, 2.0.0 and head.

Thanks!
