### PR TITLE
Use the `of` operator to detect for `to_param` and `id` in objects

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -111,7 +111,13 @@
       }
       property = object;
       if (this.get_object_type(object) === "object") {
-        property = object.to_param || object.id || object;
+        if ("to_param" in object) {
+          property = object.to_param;
+        } else if ("id" in object) {
+          property = object.id;
+        } else {
+          property = object;
+        }
         if (this.get_object_type(property) === "function") {
           property = property.call(object);
         }

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -68,7 +68,13 @@ Utils =
     return "" unless object
     property = object
     if @get_object_type(object) is "object"
-      property = object.to_param or object.id or object
+      if "to_param" of object
+        property = object.to_param
+      else if "id" of object
+        property = object.id
+      else
+        property = object
+
       property = property.call(object) if @get_object_type(property) is "function"
     property.toString()
 

--- a/spec/js_routes/rails_routes_compatibility_spec.rb
+++ b/spec/js_routes/rails_routes_compatibility_spec.rb
@@ -18,6 +18,14 @@ describe JsRoutes, "compatibility with Rails"  do
     expect(evaljs("Routes.inbox_path(0)")).to eq(routes.inbox_path(0))
   end
 
+  it "should support 0 as a to_param option" do
+    expect(evaljs("Routes.inbox_path({to_param: 0})")).to eq(routes.inbox_path(0))
+  end
+
+  it "should support 0 as an id option" do
+    expect(evaljs("Routes.inbox_path({id: 0})")).to eq(routes.inbox_path(0))
+  end
+
   it "should generate nested routing with one parameter" do
     expect(evaljs("Routes.inbox_messages_path(1)")).to eq(routes.inbox_messages_path(1))
   end


### PR DESCRIPTION
Using a path with an `id` or a `to_param` field with a value of 0 or false will result in a path that has has the output of `object.toString()` as the id, often resulting in `"[object Object]"` being set as the id. This patch will use the `of` operator to check for the existence of `to_param` and `id` fields rather than picking the first non-falsy value we can find.
