### PR TITLE
Feature: routes path specs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -123,6 +123,13 @@ var google = {id: 1, name: "Google", to_param: "google"};
 Routes.company_path(google) // => "/companies/google"
 ```
 
+For any route helper, you can access the route's path spec:
+
+```js
+Routes.users_path.spec();   // => "/users(.:format)"
+Routes.company_path.spec(); // => "/companies/:id(.:format)"
+```
+
 In order to make routes helpers available globally:
 
 ``` js

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -158,9 +158,8 @@ class JsRoutes
     url_link = generate_url_link(name, route_name, required_parts)
     _ = <<-JS.strip!
   // #{name.join('.')} => #{parent_spec}#{route.path.spec}
-  #{route_name}: function(#{build_params(required_parts)}) {
-  return Utils.build_path(#{json(required_parts)}, #{json(optional_parts)}, #{json(serialize(route.path.spec, parent_spec))}, arguments);
-  }#{",\n" + url_link if url_link.length > 0}
+  #{route_name}: route(#{json(required_parts)}, #{json(optional_parts)}, #{json(serialize(route.path.spec, parent_spec))}, arguments)
+  #{",\n" + url_link if url_link.length > 0}
   JS
   end
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -184,6 +184,46 @@
       url += anchor;
       return url;
     },
+    build_path_spec: function(route) {
+      var spec, visit_spec;
+      spec = '';
+      visit_spec = function(r, wildcard) {
+        var left, right, type;
+        if (wildcard == null) {
+          wildcard = false;
+        }
+        type = r[0], left = r[1], right = r[2];
+        switch (type) {
+          case NodeTypes.GROUP:
+            spec += '(';
+            visit_spec(left);
+            return spec += ')';
+          case NodeTypes.CAT:
+            visit_spec(left);
+            return visit_spec(right);
+          case NodeTypes.STAR:
+            return visit_spec(left, true);
+          case NodeTypes.SYMBOL:
+            if (wildcard) {
+              if (left[0] !== '*') {
+                spec += '*';
+              }
+              return spec += left;
+            } else {
+              return spec += ":" + left;
+            }
+            break;
+          case NodeTypes.SLASH:
+          case NodeTypes.DOT:
+          case NodeTypes.LITERAL:
+            return spec += left;
+          default:
+            throw new Error("Unknown Rails node type");
+        }
+      };
+      visit_spec(route);
+      return spec;
+    },
     visit: function(route, parameters, optional) {
       var left, left_part, right, right_part, type, value;
       if (optional == null) {
@@ -280,7 +320,7 @@
   };
 
   createGlobalJsRoutesObject = function() {
-    var namespace;
+    var namespace, route;
     namespace = function(mainRoot, namespaceString) {
       var current, parts;
       parts = (namespaceString ? namespaceString.split(".") : []);
@@ -290,6 +330,16 @@
       current = parts.shift();
       mainRoot[current] = mainRoot[current] || {};
       return namespace(mainRoot[current], parts.join("."));
+    };
+    route = function(required_parts, optional_parts, route_spec) {
+      var path_fn;
+      path_fn = function() {
+        return Utils.build_path(required_parts, optional_parts, route_spec, arguments);
+      };
+      path_fn.spec = function() {
+        return Utils.build_path_spec(route_spec);
+      };
+      return path_fn;
     };
     namespace(root, "NAMESPACE");
     root.NAMESPACE = ROUTES;

--- a/spec/js_routes/generated_javascript_spec.rb
+++ b/spec/js_routes/generated_javascript_spec.rb
@@ -9,13 +9,17 @@ describe JsRoutes do
 
   describe "generated js" do
     subject { JsRoutes.generate }
-    it "should have correct function without arguments signature" do
-      is_expected.to include("inboxes_path: function(options)")
+    it "should call route function for each route" do
+      is_expected.to include("inboxes_path: route(")
+      is_expected.to include("inbox_message_path: route(")
+      is_expected.to include("inbox_message_attachment_path: route(")
     end
     it "should have correct function with arguments signature" do
+      pending 'no more arguments signature with the route function (is that bad?)'
       is_expected.to include("inbox_message_path: function(_inbox_id, _id, options)")
     end
     it "should have correct function signature with unordered hash" do
+      pending 'no more arguments signature with the route function (is that bad?)'
       is_expected.to include("inbox_message_attachment_path: function(_inbox_id, _message_id, _id, options)")
     end
 
@@ -51,7 +55,7 @@ describe JsRoutes do
   describe "compiled javascript asset" do
     subject { ERB.new(File.read("app/assets/javascripts/js-routes.js.erb")).result(binding) }
     it "should have js routes code" do
-      is_expected.to include("inbox_message_path: function(_inbox_id, _id, options)")
+      is_expected.to include("inbox_message_path: route(")
     end
   end
 end

--- a/spec/js_routes/path_specs_generation_spec.rb
+++ b/spec/js_routes/path_specs_generation_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+def path_specs
+  draw_routes
+  routes = []
+  App.routes.named_routes.routes.each do |_, route|
+    if route.app.respond_to?(:superclass) && route.app.superclass == Rails::Engine && !route.path.anchored
+      route.app.routes.named_routes.routes.each do |_, engine_route|
+        parent_spec = route.try(:path).try(:spec)
+        name = [route.try(:name), engine_route.name].compact.join('_')
+        routes << [name, "#{parent_spec}#{engine_route.path.spec}"]
+      end
+    else
+      routes << [route.name, route.path.spec.to_s]
+    end
+  end
+  Hash[routes]
+end
+
+describe JsRoutes, 'path specs generation' do
+
+  before(:each) do
+    evaljs(JsRoutes.generate({}))
+  end
+
+  path_specs.each do |route, spec|
+    it "should create a spec function on the #{route}_path helper" do
+      expect(evaljs("typeof Routes.#{route}_path.spec").downcase).to eq('function')
+    end
+
+    it "should generate the correct spec for #{route}_path" do
+      expect(evaljs("Routes.#{route}_path.spec()")).to eq(spec)
+    end
+  end
+end


### PR DESCRIPTION
Closes #122 

As discussed in #122, here's a PR to add a `spec()` function to route helpers.  
It is computed in the `build_path_spec` method from the route's binary tree, with bonus codesize-per-route reduction ;)

I had to change one test and remove two because of the way routes are now built:

``` ruby
it "should have correct function without arguments signature" => it "should call route function for each route"
it "should have correct function with arguments signature" => pending
it "should have correct function signature with unordered hash" => pending
```

The reason is that we do not create one function per route with arguments names anymore. (the arguments names were not used anyway, as `build_path` was given `arguments` directly)  
Maybe we should find a way to keep the information about the arguments names somewhere?

I have added tests in the `path_specs_generation_spec.rb` spec file. All routes are loaded and two examples are dynamically created for each route, so that if one example fails, we directly know for which route (I have included the name of the route in the examples names).

Tests have been successful on my machine for all Rails versions included in Appraisal.
