### PR TITLE
Add the compact mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,6 +64,9 @@ Available options:
 * `url_links` (version >= 0.8.9) - Generate `*_url` links (in addition to default `*_path`), where url_links value is beginning of url routes
   * Example: http[s]://example.com
   * Default: false
+* `compact` (version > 0.9.9) - Remove `_path` suffix in path routes(`*_url` routes stay untouched if they were enabled)
+  * Default: false
+  * Sample route call when option is set to true: Routes.users() => `/users`
 
 ### Very Advanced Setup
 
@@ -145,7 +148,7 @@ Spork.trap_method(JsRoutes, :generate!)
 
 ## JS-Routes and heroku
 
-Heroku environment has a specific problems with setup. It is impossible to use asset pipeline in this environtment. You should use "Very Advanced Setup" schema in this case. 
+Heroku environment has a specific problems with setup. It is impossible to use asset pipeline in this environtment. You should use "Very Advanced Setup" schema in this case.
 
 For example create routes.js.erb in assets folder with needed content:
 

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -4,5 +4,8 @@ source "http://rubygems.org"
 
 gem "railties", "~> 3.2.18"
 gem "tzinfo"
+platforms :ruby do
+  gem "libv8", "<= 3.16.14.3"
+end
 
 gemspec :path=>"../"

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -275,4 +275,20 @@ describe JsRoutes, "options" do
       end
     end
   end
+
+  describe "when the compact mode is enabled" do
+    let(:_options) { { :compact => true } }
+    it "should avoid a path suffix" do
+      expect(evaljs("Routes.inboxes()")).to eq(routes.inboxes_path())
+      expect(evaljs("Routes.inbox(2)")).to eq(routes.inbox_path(2))
+    end
+
+    context "with url links" do
+      let(:_options) { { :compact => true, :url_links => "http://localhost" } }
+      it "should not strip urls" do
+        expect(evaljs("Routes.inbox(1)")).to eq(routes.inbox_path(1))
+        expect(evaljs("Routes.inbox_url(1)")).to eq("http://localhost#{routes.inbox_path(1)}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add the `compact` option which strips useless `_path` suffixes in path helper functions. It should be useful in a situations when a "Routes" object has only path functions, so instead repeat again and again 

``` js
Routes.users_path()
// it will become
Routes.users()
```
