### PR TITLE
Routes.configure(...) at JS level

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -129,6 +129,18 @@ In order to make routes helpers available globally:
 jQuery.extend(window, Routes)
 ```
 
+## Configuring in javascript
+
+Sometimes there's need to configure some options per client connection (eg. per current user's ID).
+You can do that with JavaScript's `Routes.configure()` function:
+
+``` js
+Routes.configure({prefix: '/MY-USER-UID'});
+// wil result in:
+Routes.articles_path()
+>> "/MY-USER-ID/articles"
+```
+
 ## What about security?
 
 js-routes itself do not have security holes. It makes URLs

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -133,7 +133,7 @@ class JsRoutes
       end
     end.flatten.compact
     
-    js_routes << defaults_js
+    js_routes << configure_js
 
     "{\n" + js_routes.join(",\n") + "}\n"
   end
@@ -222,10 +222,10 @@ class JsRoutes
     ]
   end
   
-  def defaults_js
+  def configure_js
     _ = <<-JS.strip!
-    defaults: function() {
-      return defaults;
+    configure: function(opts) {
+      $.extend(defaults, opts);
     }
     JS
   end

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -132,6 +132,8 @@ class JsRoutes
         build_route_if_match(route)
       end
     end.flatten.compact
+    
+    js_routes << set_prefix_js
 
     "{\n" + js_routes.join(",\n") + "}\n"
   end
@@ -218,6 +220,14 @@ class JsRoutes
       serialize(spec.left, parent_spec),
       spec.respond_to?(:right) && serialize(spec.right)
     ]
+  end
+  
+  def set_prefix_js
+    _ = <<-JS.strip!
+    set_prefix: function(path) {
+      defaults['prefix'] = path;
+    }
+    JS
   end
 end
 

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -224,8 +224,8 @@ class JsRoutes
   
   def configure_js
     _ = <<-JS.strip!
-    configure: function(opts) {
-      $.extend(defaults, opts);
+    configure: function(options) {
+      $.extend(defaults, options);
     }
     JS
   end

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -132,8 +132,6 @@ class JsRoutes
         build_route_if_match(route)
       end
     end.flatten.compact
-    
-    js_routes << configure_js
 
     "{\n" + js_routes.join(",\n") + "}\n"
   end
@@ -220,14 +218,6 @@ class JsRoutes
       serialize(spec.left, parent_spec),
       spec.respond_to?(:right) && serialize(spec.right)
     ]
-  end
-  
-  def configure_js
-    _ = <<-JS.strip!
-    configure: function(options) {
-      $.extend(defaults, options);
-    }
-    JS
   end
 end
 

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -133,7 +133,7 @@ class JsRoutes
       end
     end.flatten.compact
     
-    js_routes << set_prefix_js
+    js_routes << defaults_js
 
     "{\n" + js_routes.join(",\n") + "}\n"
   end
@@ -222,10 +222,10 @@ class JsRoutes
     ]
   end
   
-  def set_prefix_js
+  def defaults_js
     _ = <<-JS.strip!
-    set_prefix: function(path) {
-      defaults['prefix'] = path;
+    defaults: function() {
+      return defaults;
     }
     JS
   end

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -195,6 +195,9 @@ Utils =
   # This method allows to change defaults configuration
   configure: (options) ->
     $.extend defaults, options
+  
+  configuration: ->
+    defaults
 
   #
   # This is helper method to define object type.

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -190,6 +190,11 @@ Utils =
     prefix = defaults.prefix
     prefix = (if prefix.match("/$") then prefix else "#{prefix}/") if prefix isnt ""
     prefix
+  
+  #
+  # This method allows to change defaults configuration
+  configure: (options) ->
+    $.extend defaults, options
 
   #
   # This is helper method to define object type.

--- a/spec/js_routes/generated_javascript_spec.rb
+++ b/spec/js_routes/generated_javascript_spec.rb
@@ -22,6 +22,10 @@ describe JsRoutes do
     it "routes should be sorted in alphabetical order" do
       expect(subject.index("book_path")).to be <= subject.index("inboxes_path")
     end
+    
+    it "should have .configure function" do
+      is_expected.to include("configure: function(options)")
+    end
   end
 
   describe ".generate!" do


### PR DESCRIPTION
Hi

I needed `Routes.set_prefix()` to `defaults['prefix']` be setable based on currently signed in user UID so here's little fix - hoping it'll be usefull for you too.. ;) 

So with this patch we can do the following:

``` javascript
Routes.set_prefix('/ada46feca');

Routes.root_path()
>> '/ada46feca/'
```
