### PR TITLE
Remove debugger dependency from gemspec

### DIFF
--- a/js-routes.gemspec
+++ b/js-routes.gemspec
@@ -31,7 +31,6 @@ Gem::Specification.new do |s|
   if defined?(JRUBY_VERSION)
     s.add_development_dependency(%q<therubyrhino>, [">= 2.0.4"])
   else
-    s.add_development_dependency(%q<debugger>, [">= 0"]) if RUBY_VERSION =~ /\A2\.0/
     s.add_development_dependency(%q<therubyracer>, [">= 0.12.1"])
   end
 end


### PR DESCRIPTION
This PR removes the `debugger` gem as a development dependency since it is not compatible with Ruby 2.

Fixes #133.
