### PR TITLE
Ensure routes are loaded, prior to generating them

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -57,6 +57,11 @@ class JsRoutes
     end
 
     def generate(opts = {})
+      # Ensure routes are loaded. If they're not, load them.
+      if Rails.application.routes.named_routes.routes.keys.empty?
+        Rails.application.reload_routes!
+      end
+
       new(opts).generate
     end
 


### PR DESCRIPTION
Some gems and initializers attempt to generate javascript, which can include the routes file, prior to routes be initialized. This addition provides insurance against that.

Notably: This gem will not work with the [react-rails gem](https://github.com/reactjs/react-rails), due to what happens in the call on this line: https://github.com/reactjs/react-rails/blob/1c03b00b8105c78fbf674abe34be4941084bede4/lib/react/rails/railtie.rb#L62

Manifests, which may include js-routes will be rendered prior to routes being loaded, resulting in an empty set of routes being generated.

This is not, however, the only case where this bug can occur. It happens any time routes are accessed inside an initializer, or in a rails app's `after_initialize` hook.