### PR TITLE
URL escape routes.rb url to fix bad `URI(is not URI?)` error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Ensure routes are loaded, prior to generating them [#148](https://github.com/railsware/js-routes/pull/148)
 * Use `flat_map` rather than `map{...}.flatten` [#149](https://github.com/railsware/js-routes/pull/149)
+* URL escape routes.rb url to fix bad URI(is not URI?) error [#150](https://github.com/railsware/js-routes/pull/150)
 
 ## v1.0.1
 

--- a/lib/js_routes/engine.rb
+++ b/lib/js_routes/engine.rb
@@ -14,7 +14,7 @@ class JsRoutes
 
       # only sprockets >= 3.0
       if  Rails.application.assets.respond_to?(:depend_on)
-        Rails.application.assets.depend_on "file-digest://#{routes}"
+        Rails.application.assets.depend_on Rack::Utils.escape("file-digest://#{routes}")
       end
     end
   end


### PR DESCRIPTION
This fixes a bug that that crashed the Gem when you have a space in your path.