### PR TITLE
fix named routes for rails 5

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -59,7 +59,7 @@ class JsRoutes
 
     def generate(opts = {})
       # Ensure routes are loaded. If they're not, load them.
-      if Rails.application.routes.named_routes.routes.keys.empty?
+      if Rails.application.routes.named_routes.to_a.empty?
         Rails.application.reload_routes!
       end
 
@@ -133,7 +133,7 @@ class JsRoutes
   protected
 
   def js_routes
-    js_routes = Rails.application.routes.named_routes.routes.sort_by(&:to_s).flat_map do |_, route|
+    js_routes = Rails.application.routes.named_routes.to_a.sort_by(&:to_s).flat_map do |_, route|
       rails_engine_app = get_app_from_route(route)
       if rails_engine_app.respond_to?(:superclass) && rails_engine_app.superclass == Rails::Engine && !route.path.anchored
         rails_engine_app.routes.named_routes.map do |_, engine_route|


### PR DESCRIPTION
Fixes #171

This solution is compatible with all rails versions presented in Appraisal.

If you need to use it with sprockets v3, you can use:
> gem 'js-routes', github: 'vonagam/js-routes', branch: 'rails5'