### PR TITLE
Fix depend_on `config/routes.rb` if Rails.root resides in a location with special chars

### DIFF
--- a/app/assets/javascripts/js-routes.js.erb
+++ b/app/assets/javascripts/js-routes.js.erb
@@ -1,3 +1,3 @@
 <%# encoding: UTF-8 %>
-<% depend_on "file://#{Rails.root.join 'config', 'routes.rb'}" if JsRoutes::SPROCKETS3 %>
+<% depend_on Rails.root.join('config', 'routes.rb') if JsRoutes::SPROCKETS3 %>
 <%= JsRoutes.assert_usable_configuration! && JsRoutes.generate %>

--- a/spec/js_routes/generated_javascript_spec.rb
+++ b/spec/js_routes/generated_javascript_spec.rb
@@ -76,7 +76,7 @@ describe JsRoutes do
 
   describe "compiled javascript asset" do
     if JsRoutes::SPROCKETS3
-      let(:routes_path){ "file://#{Rails.root.join 'config', 'routes.rb'}" }
+      let(:routes_path){ Rails.root.join('config', 'routes.rb') }
       before { expect(self).to receive(:depend_on).with routes_path }
     end
     subject { ERB.new(File.read("app/assets/javascripts/js-routes.js.erb")).result(binding) }

--- a/spec/js_routes/zzz_last_post_rails_init_spec.rb
+++ b/spec/js_routes/zzz_last_post_rails_init_spec.rb
@@ -57,8 +57,7 @@ describe "after Rails initialization" do
 
     context "the preprocessor" do
       before(:each) do
-        path = Rails.root.join('config','routes.rb').to_s
-        path = "file://#{path}" if JsRoutes::SPROCKETS3
+        path = Rails.root.join('config','routes.rb')
         if sprockets_v3?
           expect_any_instance_of(Sprockets::Context).to receive(:depend_on).with(path)
         else


### PR DESCRIPTION
js-routes currently fails if `Rails.root` resides in a location with special chars. If you are on Mac OS X, this is easy to reproduce by moving your app folder into your iCloud sync folder.

I get the following error on a vanilla Rails 4.2.5 repo with js-routes:

```ruby
ActionView::Template::Error (couldn't find file 'file:///Users/consti/Library/Mobile Documents/com~apple~CloudDocs/Projects/JSRouteTest/config/routes.rb'):
    2: <html>
    3: <head>
    4:   <title>JSRouteTest</title>
    5:   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
    6:   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
    7:   <%= csrf_meta_tags %>
    8: </head>
  app/views/layouts/application.html.erb:5:in `_app_views_layouts_application_html_erb___3074089473060964751_70300269527340'


  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5/lib/action_dispatch/middleware/templates/rescues/_source.erb (10.4ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5/lib/action_dispatch/middleware/templates/rescues/_trace.html.erb (3.6ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb (1.4ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/actionpack-4.2.5/lib/action_dispatch/middleware/templates/rescues/template_error.html.erb within rescues/layout (82.6ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/_markup.html.erb (1.4ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/_inner_console_markup.html.erb within layouts/inlined_string (0.5ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/_prompt_box_markup.html.erb within layouts/inlined_string (0.4ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/style.css.erb within layouts/inlined_string (0.4ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/console.js.erb within layouts/javascript (74.3ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/main.js.erb within layouts/javascript (0.3ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/error_page.js.erb within layouts/javascript (0.5ms)
  Rendered /Users/consti/.rvm/gems/ruby-2.3.0/gems/web-console-2.2.1/lib/web_console/templates/index.html.erb (159.8ms)
```

This PR replaces the custom `file://` string with a plain `Pathname` class.