### PR TITLE
Remove file url scheme for sprockets 3

### DIFF
--- a/app/assets/javascripts/js-routes.js.erb
+++ b/app/assets/javascripts/js-routes.js.erb
@@ -1,3 +1,3 @@
 <%# encoding: UTF-8 %>
-<% depend_on "file://#{Rails.root.join 'config', 'routes.rb'}" if JsRoutes::SPROCKETS3 %>
+<% depend_on "#{Rails.root.join 'config', 'routes.rb'}" if JsRoutes::SPROCKETS3 %>
 <%= JsRoutes.assert_usable_configuration! && JsRoutes.generate %>

--- a/spec/js_routes/generated_javascript_spec.rb
+++ b/spec/js_routes/generated_javascript_spec.rb
@@ -76,7 +76,7 @@ describe JsRoutes do
 
   describe "compiled javascript asset" do
     if JsRoutes::SPROCKETS3
-      let(:routes_path){ "file://#{Rails.root.join 'config', 'routes.rb'}" }
+      let(:routes_path){ "#{Rails.root.join 'config', 'routes.rb'}" }
       before { expect(self).to receive(:depend_on).with routes_path }
     end
     subject { ERB.new(File.read("app/assets/javascripts/js-routes.js.erb")).result(binding) }

--- a/spec/js_routes/zzz_last_post_rails_init_spec.rb
+++ b/spec/js_routes/zzz_last_post_rails_init_spec.rb
@@ -58,7 +58,6 @@ describe "after Rails initialization" do
     context "the preprocessor" do
       before(:each) do
         path = Rails.root.join('config','routes.rb').to_s
-        path = "file://#{path}" if JsRoutes::SPROCKETS3
         if sprockets_v3?
           expect_any_instance_of(Sprockets::Context).to receive(:depend_on).with(path)
         else


### PR DESCRIPTION
With sprockets 3, `file://` passed to [depend_on](https://github.com/rails/sprockets#the-depend_on-directive) causes `Sprockets::FileNotFound` error.

```
Sprockets::FileNotFound - couldn't find file 'file:///Users/ihara/Documents/work/kintan/config/routes.rb':
  sprockets (3.5.2) lib/sprockets/resolve.rb:64:in `resolve!'
  sprockets (3.5.2) lib/sprockets/context.rb:88:in `resolve'
  sprockets (3.5.2) lib/sprockets/legacy.rb:259:in `resolve_with_compat'
  sprockets (3.5.2) lib/sprockets/context.rb:116:in `depend_on'
  js-routes (1.2.2) app/assets/javascripts/js-routes.js.erb:2:in `_evaluate_template'
  ...
```

gem's versions are here

* rails (4.2.5)
* js-routes (1.2.2)
* sprockets (3.5.2)
* sprockets-rails (3.0.0)

Do you need to add `file://`?