### PR TITLE
Sort by the route key instead of the entire AST.

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -150,7 +150,7 @@ class JsRoutes
   protected
 
   def js_routes
-    js_routes = Rails.application.routes.named_routes.to_a.sort_by(&:to_s).flat_map do |_, route|
+    js_routes = Rails.application.routes.named_routes.to_a.sort_by(&:first).flat_map do |_, route|
       rails_engine_app = get_app_from_route(route)
       if rails_engine_app.respond_to?(:superclass) && rails_engine_app.superclass == Rails::Engine && !route.path.anchored
         rails_engine_app.routes.named_routes.map do |_, engine_route|


### PR DESCRIPTION
This fixes #181.

Sorting `Rails.application.routes.named_routes.to_a` by `to_s` was introduced in d7dcfd45ae59dd8bea595f3bc5598567a0ec82f5, which was supposed to sort every route by key.

Rails.application.routes.named_routes.to_a.first.to_s returns a string like this:

```
"[:root, #<ActionDispatch::Journey::Route:0x0000a8ecc362f8 @name="root", @app=#<ActionDispatch::Routing::RouteSet::Dispatcher:0x0000a8ecc370b8 @defaults={:controller=>"application", :action=>"index"}>, @path=#<ActionDispatch::Journey::Path::Pattern:0x0000a8ecc36f78 @spec=#<ActionDispatch::Journey::Nodes::Slash:0x0000a8ecc486d8 @left="/", @memo=nil>, @requirements={}, @separators="/.?", @anchored=true, @names=[], @optional_names=[], @required_names=[], @re=nil, @offsets=nil>, @constraints={:required_defaults=>[:controller, :action], :request_method=>/^GET$/}, @defaults={:controller=>"application", :action=>"index"}, @required_defaults=nil, @required_parts=[], @parts=[], @decorated_ast=nil, @precedence=1, @path_formatter=#<ActionDispatch::Journey::Format:0x0000a8ecc36280 @parts=["/"], @children=[], @parameters=[]>>]"
```

This change will sort the routes using only their path, ignoring the ActionDispatch::Journey::Route object.