### PR TITLE
Filter "subdomain" default parameter

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -35,7 +35,7 @@ class JsRoutes
   }
 
   LAST_OPTIONS_KEY = "options".freeze
-  FILTERED_DEFAULT_PARTS = [:controller, :action]
+  FILTERED_DEFAULT_PARTS = [:controller, :action, :subdomain]
 
   class Options < Struct.new(*DEFAULTS.keys)
     def to_hash

--- a/spec/js_routes/rails_routes_compatibility_spec.rb
+++ b/spec/js_routes/rails_routes_compatibility_spec.rb
@@ -66,6 +66,10 @@ describe JsRoutes, "compatibility with Rails"  do
       expect(evaljs("Routes.api_purchases_path()")).to eq(routes.api_purchases_path)
     end
 
+    it 'should support route default subdomain' do
+      expect(evaljs("Routes.backend_root_path()")).to eq(routes.backend_root_path)
+    end
+
     it "should support default format override" do
       expect(evaljs("Routes.api_purchases_path({format: 'xml'})")).to eq(routes.api_purchases_path(format: 'xml'))
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,7 +116,7 @@ def draw_routes
 
     get '/привет' => "foo#foo", :as => :hello
     get '(/o/:organization)/search/:q' => "foo#foo", as: :search
-      
+
     resources :sessions, :only => [:new, :create, :destroy], :protocol => 'https'
 
     get '/' => 'sso#login', host: 'sso.example.com', as: :sso
@@ -129,6 +129,12 @@ def draw_routes
 
     resources :budgies do
       get "descendents"
+    end
+
+    constraints subdomain: 'backend' do
+      namespace :backend, path: '' do
+        root 'backend#index'
+      end
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -131,10 +131,8 @@ def draw_routes
       get "descendents"
     end
 
-    constraints subdomain: 'backend' do
-      namespace :backend, path: '' do
-        root 'backend#index'
-      end
+    namespace :backend, path: '', constraints: {subdomain: 'backend'} do
+      root to: 'backend#index'
     end
 
   end


### PR DESCRIPTION
Having routes with `constraints: {subdomain: 'backend'}`, it generates paths, such as `/?subdomain=backend`.