### PR TITLE
Default prefix setting to Rails relative URL root setting

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ Available options:
   * Default: `Routes`
 * `prefix` - String representing a url path to prepend to all paths.
   * Example: `http://yourdomain.com`. This will cause route helpers to generate full path only.
-  * Default: value of Rails.application.config.relative_url_root or RAILS_RELATIVE_URL_ROOT env variable
+  * Default: Rails.application.config.relative_url_root
 * `camel_case` (version >= 0.8.8) - Generate camel case route names.
   * Default: false
 * `url_links` (version >= 0.8.9) - Generate `*_url` helpers (in addition to the default `*_path` helpers).
@@ -72,12 +72,6 @@ Available options:
   * Default: `nil`. Uses built-in serializer
   * Example: `jQuery.param` - use jQuery's serializer algorithm. You can attach serialize function from your favorite AJAX framework.
   * Example: `MyApp.custom_serialize` - use completely custom serializer of your application.
-
-**Important:** If you've installed your application in a sub-path or sub-URI of your server instead of at the root, you need to set the `RAILS_RELATIVE_URL_ROOT` environment variable to the correct path prefix for your application when you precompile assets. Eg., if your application's base URL is "https://appl.example.com/Application1", the command to precompile assets would be:
-```
-RAILS_RELATIVE_URL_ROOT=/Application1 RAILS_ENV=production bundle exec rake assets:precompile
-```
-The environment variable is only needed for precompilation of assets, at any other time (eg. when assets are compiled on-the-fly as in the development environment) Rails will set the relative URL root correctly on it's own.
 
 ### Very Advanced Setup
 
@@ -114,6 +108,15 @@ JsRoutes.generate!("#{path}/app_routes.js", :namespace => "AppRoutes", :exclude 
 JsRoutes.generate!("#{path}/adm_routes.js", :namespace => "AdmRoutes", :include => /^admin_/)
 JsRoutes.generate!("#{path}/api_routes.js", :namespace => "ApiRoutes", :include => /^api_/, :default_url_options => {:format => "json"})
 ```
+
+### Rails relative URL root
+
+If you've installed your application in a sub-path or sub-URI of your server instead of at the root, you need to set the `RAILS_RELATIVE_URL_ROOT` environment variable to the correct path prefix for your application when you precompile assets. Eg., if your application's base URL is "https://appl.example.com/Application1", the command to precompile assets would be:
+```
+RAILS_RELATIVE_URL_ROOT=/Application1 RAILS_ENV=production bundle exec rake assets:precompile
+```
+The environment variable is only needed for precompilation of assets, at any other time (eg. when assets are compiled on-the-fly as in the development environment) Rails will set the relative URL root correctly on it's own.
+
 
 ## Usage
 

--- a/Readme.md
+++ b/Readme.md
@@ -58,7 +58,7 @@ Available options:
   * Default: `Routes`
 * `prefix` - String representing a url path to prepend to all paths.
   * Example: `http://yourdomain.com`. This will cause route helpers to generate full path only.
-  * Default: blank
+  * Default: value of Rails.application.config.relative_url_root or RAILS_RELATIVE_URL_ROOT env variable
 * `camel_case` (version >= 0.8.8) - Generate camel case route names.
   * Default: false
 * `url_links` (version >= 0.8.9) - Generate `*_url` helpers (in addition to the default `*_path` helpers).
@@ -72,6 +72,12 @@ Available options:
   * Default: `nil`. Uses built-in serializer
   * Example: `jQuery.param` - use jQuery's serializer algorithm. You can attach serialize function from your favorite AJAX framework.
   * Example: `MyApp.custom_serialize` - use completely custom serializer of your application.
+
+**Important:** If you've installed your application in a sub-path or sub-URI of your server instead of at the root, you need to set the `RAILS_RELATIVE_URL_ROOT` environment variable to the correct path prefix for your application when you precompile assets. Eg., if your application's base URL is "https://appl.example.com/Application1", the command to precompile assets would be:
+```
+RAILS_RELATIVE_URL_ROOT=/Application1 RAILS_ENV=production bundle exec rake assets:precompile
+```
+The environment variable is only needed for precompilation of assets, at any other time (eg. when assets are compiled on-the-fly as in the development environment) Rails will set the relative URL root correctly on it's own.
 
 ### Very Advanced Setup
 

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -104,7 +104,7 @@ class JsRoutes
       "APP_CLASS"           => Rails.application.class.to_s,
       "NAMESPACE"           => @options[:namespace],
       "DEFAULT_URL_OPTIONS" => json(@options[:default_url_options].merge(deprecate_url_options)),
-      "PREFIX"              => @options[:prefix] || Rails.application.config.relative_url_root,
+      "PREFIX"              => @options[:prefix] || Rails.application.config.relative_url_root || "",
       "NODE_TYPES"          => json(NODE_TYPES),
       "SERIALIZER"          => @options[:serializer] || "null",
       "ROUTES"              => js_routes,

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -104,7 +104,7 @@ class JsRoutes
       "APP_CLASS"           => Rails.application.class.to_s,
       "NAMESPACE"           => @options[:namespace],
       "DEFAULT_URL_OPTIONS" => json(@options[:default_url_options].merge(deprecate_url_options)),
-      "PREFIX"              => @options[:prefix] || "",
+      "PREFIX"              => @options[:prefix] || Rails.application.config.relative_url_root,
       "NODE_TYPES"          => json(NODE_TYPES),
       "SERIALIZER"          => @options[:serializer] || "null",
       "ROUTES"              => js_routes,


### PR DESCRIPTION
Issue #186:
Take the default for the `prefix` configuration setting from the Rails relative URL root setting (`Rails.application.config.relative_url_root`).
Add a note in the README about how to set the relative URL root correctly during asset precompilation.