### PR TITLE
Failing spec

### DIFF
--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -186,9 +186,18 @@ describe JsRoutes, "options" do
 
   describe "default_url_options" do
     context "with optional route parts" do
-      let(:_options) { {:default_url_options => {:optional_id => "12", :format => "json"}}}
-      it "should use this opions to fill optional parameters" do
-        expect(evaljs("Routes.things_path()")).to eq(routes.things_path(:optional_id => 12, :format => "json"))
+      context "provided" do
+        let(:_options) { { :default_url_options => { :optional_id => "12", :format => "json" } } }
+        it "should use this opions to fill optional parameters" do
+          expect(evaljs("Routes.things_path()")).to eq(routes.things_path(:optional_id => 12, :format => "json"))
+        end
+      end
+
+      context "not provided" do
+        let(:_options) { { :default_url_options => { :format => "json" } } }
+        it "breaks" do
+          expect(evaljs("Routes.foo_all_path()")).to eq(routes.foo_all_path(:format => "json"))
+        end
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,6 +104,7 @@ def draw_routes
     get "/:controller(/:action(/:id))" => "classic#classic", :as => :classic
 
     get "/other_optional/(:optional_id)" => "foo#foo", :as => :foo
+    get '/other_optional(/*optional_id)' => 'foo#foo', :as => :foo_all
 
     get 'books/*section/:title' => 'books#show', :as => :book
     get 'books/:title/*section' => 'books#show', :as => :book_title


### PR DESCRIPTION
```ruby
Failure/Error: expect(evaljs("Routes.foo_all_path()")).to eq(routes.foo_all_path(:format => "json"))
    expected: "/other_optional.json"
         got: "/other_optional/.json"
```