### PR TITLE
Drop 1.9.3 support and add indexOf helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 cache: bundler
 
+before_install:
+  - gem install bundler # need for jruby and ruby-head
+
 rvm:
-  - 1.9.3
   - 2.0
   - 2.1
   - 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## master
 
+* Remove support 1.9.3
+* Add helper for indexOf, if no native implementation in JS engine
+
 ## v1.2.6
 
 * Use default prefix from `Rails.application.config.relative_url_root` #186

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## master
 
-* Remove support 1.9.3
+* Drop support 1.9.3
 * Add helper for indexOf, if no native implementation in JS engine
 
 ## v1.2.6

--- a/js-routes.gemspec
+++ b/js-routes.gemspec
@@ -29,9 +29,7 @@ Gem::Specification.new do |s|
   if defined?(JRUBY_VERSION)
     s.add_development_dependency(%q<therubyrhino>, [">= 2.0.4"])
   else
-    if RUBY_VERSION >= "2.0.0"
-      s.add_development_dependency(%q<byebug>)
-    end
+    s.add_development_dependency(%q<byebug>)
     s.add_development_dependency(%q<therubyracer>, [">= 0.12.1"])
   end
 end

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -173,7 +173,7 @@ Based on Rails routes of APP_CLASS
       for (key in options) {
         if (!hasProp.call(options, key)) continue;
         value = options[key];
-        if (ReservedOptions.indexOf(key) >= 0) {
+        if (this.indexOf(ReservedOptions, key) >= 0) {
           result[key] = value;
         } else {
           url_parameters[key] = value;
@@ -245,7 +245,7 @@ Based on Rails routes of APP_CLASS
       }
     },
     is_optional_node: function(node) {
-      return node === NodeTypes.STAR || node === NodeTypes.SYMBOL || node === NodeTypes.CAT;
+      return this.indexOf([NodeTypes.STAR, NodeTypes.SYMBOL, NodeTypes.CAT], node) >= 0;
     },
     build_path_spec: function(route, wildcard) {
       var left, right, type;
@@ -375,6 +375,24 @@ Based on Rails routes of APP_CLASS
       } else {
         return typeof obj;
       }
+    },
+    indexOf: function(array, element) {
+      if (Array.prototype.indexOf) {
+        return array.indexOf(element);
+      } else {
+        return this.indexOfImplementation(array, element);
+      }
+    },
+    indexOfImplementation: function(array, element) {
+      var el, i, j, len, result;
+      result = -1;
+      for (i = j = 0, len = array.length; j < len; i = ++j) {
+        el = array[i];
+        if (el === element) {
+          result = i;
+        }
+      }
+      return result;
     }
   };
 

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -109,7 +109,7 @@ Utils =
     url_parameters = {}
     result['url_parameters'] = url_parameters
     for own key, value of options
-      if ReservedOptions.indexOf(key) >= 0
+      if @indexOf(ReservedOptions, key) >= 0
         result[key] = value
       else
         url_parameters[key] = value
@@ -183,8 +183,7 @@ Utils =
         throw new Error("Unknown Rails node type")
 
 
-  is_optional_node: (node) ->
-    node == NodeTypes.STAR or node == NodeTypes.SYMBOL or node == NodeTypes.CAT
+  is_optional_node: (node) -> @indexOf([NodeTypes.STAR, NodeTypes.SYMBOL, NodeTypes.CAT], node) >= 0
 
   #
   # This method build spec for route
@@ -310,6 +309,13 @@ Utils =
     return root.jQuery.type(obj) if root.jQuery and root.jQuery.type?
     return "#{obj}" unless obj?
     (if typeof obj is "object" or typeof obj is "function" then @_classToType()[Object::toString.call(obj)] or "object" else typeof obj)
+
+  # indexOf helper
+  indexOf: (array, element) -> if Array::indexOf then array.indexOf(element) else @indexOfImplementation(array, element)
+  indexOfImplementation: (array, element) ->
+    result = -1
+    (result = i for el, i in array when el is element)
+    result
 
 # globalJsObject
 createGlobalJsRoutesObject = ->

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -421,14 +421,7 @@ describe JsRoutes, "options" do
       end
 
       before do
-        jscontext['window'] = {
-          :location => {
-            :protocol => current_protocol,
-            :hostname => current_hostname,
-            :port => current_port,
-            :host => current_host
-          }
-        }
+        jscontext.eval("window = {'location': {'protocol': '#{current_protocol}', 'hostname': '#{current_hostname}', 'port': '#{current_port}', 'host': '#{current_host}'}}")
       end
 
       context "without specifying a default host" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ if defined?(JRUBY_VERSION)
   require 'rhino'
   JS_LIB_CLASS = Rhino
 else
-  require "v8"
+  require 'v8'
   JS_LIB_CLASS = V8
 end
 


### PR DESCRIPTION
Reasons:
 
* New v8 engine (5.x instead 3.x in therubyracer gem)
* Simple interface, which provide better way to debug JS output (result - `log` function much simpler)

Reason to remove "no `indexOf`" test:

* no engines, which is not have this basic function - https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf look at "Browser compatibility" section
* we already using `indexOf` in another places and not checking availability. Example: https://github.com/railsware/js-routes/blob/master/lib/routes.js.coffee#L112