### PR TITLE
Update Sprockets extension to work with Sprockets 2, 3, 4

### DIFF
--- a/lib/js_routes/engine.rb
+++ b/lib/js_routes/engine.rb
@@ -32,7 +32,7 @@ class Engine < ::Rails::Engine
   v2                = Gem::Dependency.new('', ' ~> 2')
   v3                = Gem::Dependency.new('', ' ~> 3')
   v4                = Gem::Dependency.new('', ' >= 4')
-  sprockets_version = Sprockets::VERSION
+  sprockets_version = Gem::Version.new(Sprockets::VERSION).release
   initializer_args  = case sprockets_version
                         when -> (v) { v2.match?('', v) }
                           { after: "sprockets.environment" }

--- a/lib/js_routes/engine.rb
+++ b/lib/js_routes/engine.rb
@@ -29,19 +29,41 @@ end
 
 class Engine < ::Rails::Engine
   require 'sprockets/version'
-  sprockets3       = Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('3.0.0')
-  initializer_args = if sprockets3
-                       { after: :engines_blank_point, before: :finisher_hook }
-                     else
-                       { after: "sprockets.environment" }
-                     end
+  v2                = Gem::Dependency.new('', ' ~> 2')
+  v3                = Gem::Dependency.new('', ' ~> 3')
+  v4                = Gem::Dependency.new('', ' >= 4')
+  sprockets_version = Sprockets::VERSION
+  initializer_args  = case sprockets_version
+                        when -> (v) { v2.match?('', v) }
+                          { after: "sprockets.environment" }
+                        when -> (v) { v3.match?('', v) || v4.match?('', v) }
+                          { after: :engines_blank_point, before: :finisher_hook }
+                        else
+                          raise StandardError, "Sprockets version #{sprockets_version} is not supported"
+                      end
 
   initializer 'js-routes.dependent_on_routes', initializer_args do
-    env = if sprockets3
-            Sprockets
-          else
-            Rails.application.assets
+    case sprockets_version
+      when -> (v) { v2.match?('', v) }
+        if Rails.application.assets.respond_to?(:register_preprocessor)
+          routes = Rails.root.join('config', 'routes.rb').to_s
+          Rails.application.assets.register_preprocessor 'application/javascript', :'js-routes_dependent_on_routes' do |ctx, data|
+            ctx.depend_on(routes) if ctx.logical_path == 'js-routes'
+            data
           end
-    env.register_preprocessor 'application/javascript', JsRoutesSprocketsExtension
+        end
+      when -> (v) { v3.match?('', v) }
+        Rails.application.config.assets.configure do |config|
+          routes = Rails.root.join('config', 'routes.rb').to_s
+          config.register_preprocessor 'application/javascript', :'js-routes_dependent_on_routes' do |ctx, data|
+            ctx.depend_on(routes) if ctx.logical_path == 'js-routes'
+            data
+          end
+        end
+      when -> (v) { v4.match?('', v) }
+        Sprockets.register_preprocessor 'application/javascript', JsRoutesSprocketsExtension
+      else
+        raise StandardError, "Sprockets version #{sprockets_version} is not supported"
+    end
   end
 end

--- a/lib/js_routes/engine.rb
+++ b/lib/js_routes/engine.rb
@@ -28,6 +28,7 @@ end
 
 
 class Engine < ::Rails::Engine
+  require 'sprockets/version'
   sprockets3       = Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('3.0.0')
   initializer_args = if sprockets3
                        { after: :engines_blank_point, before: :finisher_hook }
@@ -36,6 +37,11 @@ class Engine < ::Rails::Engine
                      end
 
   initializer 'js-routes.dependent_on_routes', initializer_args do
-    Sprockets.register_preprocessor 'application/javascript', JsRoutesSprocketsExtension
+    env = if sprockets3
+            Sprockets
+          else
+            Rails.application.assets
+          end
+    env.register_preprocessor 'application/javascript', JsRoutesSprocketsExtension
   end
 end


### PR DESCRIPTION
Sprockets 3.x display deprecation warning: You are using the a deprecated processor interface #<Proc:0x007f9002044f90@/.../gems/ruby-2.3.1/gems/js-routes-1.2.7/lib/js_routes/engine.rb:11>.
Please update your processor interface:
https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors

I've followed the guide and updated the engine to support all versions of sprockets.

This makes two tests fail, but it looks like it's because those tests are implementation specific. I've checked this code on three fresh applications with sprockets 2.12.4, 3.7.0 and 4.0.0beta2. JavaScript `Routes` object is correctly created in all three cases.