### PR TITLE
Try to fix sprockets hook when using different sprockets/rails versions

### DIFF
--- a/lib/js_routes/engine.rb
+++ b/lib/js_routes/engine.rb
@@ -42,19 +42,34 @@ class Engine < ::Rails::Engine
                           raise StandardError, "Sprockets version #{sprockets_version} is not supported"
                       end
 
+  is_running_rails = defined?(Rails) && Rails.respond_to?(:version)
+  is_running_rails_32 = is_running_rails && Rails.version.match(/3\.2/)
+
   initializer 'js-routes.dependent_on_routes', initializer_args do
     case sprockets_version
       when  -> (v) { v2.match?('', v) },
             -> (v) { v3.match?('', v) },
             -> (v) { v37.match?('', v) }
+
+      # It seems rails 3.2 is not working if
+      # `Rails.application.config.assets.configure` is used for
+      # registering preprocessor
+      if is_running_rails_32
+        Rails.application.assets.register_preprocessor(
+          "application/javascript",
+          JsRoutesSprocketsExtension,
+        )
+      else
+        # Other rails version, assumed newer
         Rails.application.config.assets.configure do |config|
           config.register_preprocessor(
             "application/javascript",
             JsRoutesSprocketsExtension,
           )
         end
-      else
-        raise StandardError, "Sprockets version #{sprockets_version} is not supported"
+      end
+    else
+      raise StandardError, "Sprockets version #{sprockets_version} is not supported"
     end
   end
 end

--- a/lib/js_routes/engine.rb
+++ b/lib/js_routes/engine.rb
@@ -44,24 +44,15 @@ class Engine < ::Rails::Engine
 
   initializer 'js-routes.dependent_on_routes', initializer_args do
     case sprockets_version
-      when -> (v) { v2.match?('', v) }
-        if Rails.application.assets.respond_to?(:register_preprocessor)
-          routes = Rails.root.join('config', 'routes.rb').to_s
-          Rails.application.assets.register_preprocessor 'application/javascript', :'js-routes_dependent_on_routes' do |ctx, data|
-            ctx.depend_on(routes) if ctx.logical_path == 'js-routes'
-            data
-          end
-        end
-      when -> (v) { v3.match?('', v) }
+      when  -> (v) { v2.match?('', v) },
+            -> (v) { v3.match?('', v) },
+            -> (v) { v37.match?('', v) }
         Rails.application.config.assets.configure do |config|
-          routes = Rails.root.join('config', 'routes.rb').to_s
-          config.register_preprocessor 'application/javascript', :'js-routes_dependent_on_routes' do |ctx, data|
-            ctx.depend_on(routes) if ctx.logical_path == 'js-routes'
-            data
-          end
+          config.register_preprocessor(
+            "application/javascript",
+            JsRoutesSprocketsExtension,
+          )
         end
-      when -> (v) { v37.match?('', v) }
-        Sprockets.register_preprocessor 'application/javascript', JsRoutesSprocketsExtension
       else
         raise StandardError, "Sprockets version #{sprockets_version} is not supported"
     end


### PR DESCRIPTION
Changed the code to be like 
https://github.com/fnando/i18n-js/pull/418

This changed is tested by me with 
- sprockets 3.7
- rails 4.1.x
using method specified in #211 

`Rails.application.assets.preprocessors` does include `JsRoutesSprocketsExtension`
after this change
