### PR TITLE
Added `application` option

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -103,7 +103,7 @@ class JsRoutes
   def generate
     {
       "GEM_VERSION"         => JsRoutes::VERSION,
-      "APP_CLASS"           => Rails.application.class.to_s,
+      "APP_CLASS"           => application.class.to_s,
       "NAMESPACE"           => @options[:namespace],
       "DEFAULT_URL_OPTIONS" => json(@options[:default_url_options].merge(deprecate_url_options)),
       "PREFIX"              => @options[:prefix] || Rails.application.config.relative_url_root || "",
@@ -152,8 +152,12 @@ class JsRoutes
 
   protected
 
+  def application
+    @options[:application] || Rails.application
+  end
+
   def js_routes
-    js_routes = Rails.application.routes.named_routes.to_a.sort_by(&:first).flat_map do |_, route|
+    js_routes = application.routes.named_routes.to_a.sort_by(&:first).flat_map do |_, route|
       [build_route_if_match(route)] + mounted_app_routes(route)
     end.compact
     "{\n" + js_routes.join(",\n") + "}\n"

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -486,4 +486,12 @@ describe JsRoutes, "options" do
       expect(evaljs("Routes.inbox_message_path({inbox_id: 1, id: 2, __options__: true})")).to eq(routes.inbox_message_path(inbox_id: 1, id: 2))
     end
   end
+
+  describe "when application is specified" do
+    let(:_options) { {:application => BlogEngine::Engine} }
+
+    it "should include specified engine route" do
+      expect(evaljs("Routes.posts_path()")).not_to be_nil
+    end
+  end
 end


### PR DESCRIPTION
Hey, first off, thanks for the awesome work on this gem! 👍 

This adds the ability to generate routes from a Rails engine.

```erb
<%= JsRoutes.generate(engine: Blazer::Engine) %>
```

I've attempted to use this for [Blazer](https://github.com/ankane/blazer), but am running into issues with different route names depending on where users mount the engine. If mounted at `/`, it generates `Routes.blazer_queries_path()`, but if namespaced under `admin`, it generates `Routes.admin_blazer_queries_path()`, which makes sense for the typical setup.

Let me know your thoughts. Thanks!