### PR TITLE
Subdomain added as possible default_url_option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ Available options:
 
 * `default_url_options` - default parameters used when generating URLs
   * Option is configurable at JS level with `Routes.configure()`
-  * Example: {:format => "json", :trailing\_slash => true, :protocol => "https", :host => "example.com", :port => 3000}
+  * Example: {:format => "json", :trailing\_slash => true, :protocol => "https", :subdomain => "api", :host => "example.com", :port => 3000}
   * Default: {}
 * `exclude` - Array of regexps to exclude from js routes.
   * Default: []

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -22,7 +22,7 @@ Based on Rails routes of APP_CLASS
 
   DeprecatedBehavior = DEPRECATED_BEHAVIOR;
 
-  ReservedOptions = ['anchor', 'trailing_slash', 'host', 'port', 'protocol'];
+  ReservedOptions = ['anchor', 'trailing_slash', 'subdomain', 'host', 'port', 'protocol'];
 
   Utils = {
     configuration: {

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -352,7 +352,7 @@ Based on Rails routes of APP_CLASS
       return path_fn;
     },
     route_url: function(route_defaults) {
-      var hostname, port, protocol;
+      var hostname, port, protocol, subdomain;
       if (typeof route_defaults === 'string') {
         return route_defaults;
       }
@@ -360,10 +360,11 @@ Based on Rails routes of APP_CLASS
       if (!hostname) {
         return '';
       }
+      subdomain = route_defaults.subdomain ? route_defaults.subdomain + '.' : '';
       protocol = route_defaults.protocol || Utils.current_protocol();
       port = route_defaults.port || (!route_defaults.host ? Utils.current_port() : void 0);
       port = port ? ":" + port : '';
-      return protocol + "://" + hostname + port;
+      return protocol + "://" + subdomain + hostname + port;
     },
     has_location: function() {
       return (typeof window !== "undefined" && window !== null ? window.location : void 0) != null;

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -15,6 +15,7 @@ DeprecatedBehavior = DEPRECATED_BEHAVIOR
 ReservedOptions = [
   'anchor'
   'trailing_slash'
+  'subdomain'
   'host'
   'port'
   'protocol'

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -281,11 +281,12 @@ Utils =
 
     return '' unless hostname
 
+    subdomain = route_defaults.subdomain ? route_defaults.subdomain + '.' : ''
     protocol = route_defaults.protocol || Utils.current_protocol()
     port = route_defaults.port || (Utils.current_port() unless route_defaults.host)
     port = if port then ":#{port}" else ''
 
-    protocol + "://" + hostname + port
+    protocol + "://" + subdomain + hostname + port
 
   has_location: -> window?.location?
 


### PR DESCRIPTION
Sometimes it is useful to have dynamically determined base url with statically declared subdomains (as ex. for 'api.' subdomain in RESTful applications), so I've added the 'subdomain' as possible default_url_option.