### PR TITLE
Change ParameterMissing custom error implementation

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -12,7 +12,11 @@ Based on Rails routes of APP_CLASS
 
   function ParameterMissing(message, fileName, lineNumber) {
     var instance = new Error(message, fileName, lineNumber);
-    Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+    if(Object.setPrototypeOf) {
+      Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+    } else {
+      instance.__proto__ = this.__proto__;
+    }
     if (Error.captureStackTrace) {
       Error.captureStackTrace(instance, ParameterMissing);
     }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -10,11 +10,29 @@ Based on Rails routes of APP_CLASS
 
   root = typeof exports !== "undefined" && exports !== null ? exports : this;
 
-  ParameterMissing = function(message) {
-    this.message = message;
-  };
+  function ParameterMissing(message, fileName, lineNumber) {
+    var instance = new Error(message, fileName, lineNumber);
+    Object.setPrototypeOf(instance, Object.getPrototypeOf(this));
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(instance, ParameterMissing);
+    }
+    return instance;
+  }
 
-  ParameterMissing.prototype = new Error();
+  ParameterMissing.prototype = Object.create(Error.prototype, {
+    constructor: {
+      value: Error,
+      enumerable: false,
+      writable: true,
+      configurable: true
+    }
+  });
+
+  if (Object.setPrototypeOf){
+    Object.setPrototypeOf(ParameterMissing, Error);
+  } else {
+    ParameterMissing.__proto__ = Error;
+  }
 
   NodeTypes = NODE_TYPES;
 

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -7,7 +7,10 @@ root = (exports ? this)
 
 ParameterMissing = (message, fileName, lineNumber) ->
   instance = new Error(message, fileName, lineNumber)
-  Object.setPrototypeOf instance, Object.getPrototypeOf(this)
+  if Object.setPrototypeOf
+    Object.setPrototypeOf instance, Object.getPrototypeOf(this)
+  else
+    instance.__proto__ = this.__proto__
   if Error.captureStackTrace
     Error.captureStackTrace instance, ParameterMissing
   instance

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -5,8 +5,24 @@ Based on Rails routes of APP_CLASS
 # root is this
 root = (exports ? this)
 
-ParameterMissing = (@message) -> #
-ParameterMissing:: = new Error()
+ParameterMissing = (message, fileName, lineNumber) ->
+  instance = new Error(message, fileName, lineNumber)
+  Object.setPrototypeOf instance, Object.getPrototypeOf(this)
+  if Error.captureStackTrace
+    Error.captureStackTrace instance, ParameterMissing
+  instance
+
+ParameterMissing.prototype = Object.create(Error.prototype, constructor:
+  value: Error
+  enumerable: false
+  writable: true
+  configurable: true
+)
+
+if Object.setPrototypeOf
+  Object.setPrototypeOf(ParameterMissing, Error)
+else
+  ParameterMissing.__proto__ = Error
 
 NodeTypes = NODE_TYPES
 SpecialOptionsKey = SPECIAL_OPTIONS_KEY

--- a/spec/js_routes/rails_routes_compatibility_spec.rb
+++ b/spec/js_routes/rails_routes_compatibility_spec.rb
@@ -25,6 +25,19 @@ describe JsRoutes, "compatibility with Rails"  do
       .to raise_error('Route parameter missing: title')
   end
 
+  it "should produce error stacktraces including function names" do
+     stacktrace = evaljs("
+        (function(){
+          try {
+            Routes.thing_path()
+          } catch(e) {
+            return e.stack;
+          }
+        })()
+      ")
+    expect(stacktrace).to include "thing_path"
+  end
+
   it "should support 0 as a member parameter" do
     expect(evaljs("Routes.inbox_path(0)")).to eq(test_routes.inbox_path(0))
   end


### PR DESCRIPTION
With the current implementation of the ParameterMissing custom error type, function names can become obfuscated or dropped in the resulting stack trace. This PR updates the implementation based on the recommendations [from the mozilla developer docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#ES5_Custom_Error_Object).

## Example

I was able to reproduce the problem in our application with the help of [error-stack-parser](https://github.com/stacktracejs/error-stack-parser) to print the function names from the stacktrace.

```javascript
import Routes from 'routes';
import ErrorStackParser from 'error-stack-parser';

function doSomething() {
  // should take an argument
  Routes.account_path();
}

class SomeView {
  handleClick() {
    try {
      doSomething();
    } catch (error) {
      console.log(ErrorStackParser.parse(error).map(frame => frame.functionName));
    }
  }
}
```
![screenshot 2018-01-10 16 00 34](https://user-images.githubusercontent.com/555044/34802794-62b6c2f2-f624-11e7-804b-22c23556fb0e.png)

Notice the function `doSomething` is not present in the stacktrace, nor is `handleClick`. Also this stacktrace contains a lot of webpack require code because it was generated at import/definition time rather than runtime.

Now with the change in this PR:

![screenshot 2018-01-10 16 38 20](https://user-images.githubusercontent.com/555044/34802848-b4febc04-f624-11e7-8dbb-af235248e5d0.png)

Notice that we can now see which route function caused the problem (`account_path`), as well as the calling function chain.