### PR TITLE
Avoid rewrite js file if content wasn't changed.

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -150,8 +150,15 @@ class JsRoutes
     # https://github.com/railsware/js-routes/issues/7
     Rails.configuration.after_initialize do
       file_name ||= self.class.configuration['file']
-      File.open(Rails.root.join(file_name), 'w') do |f|
-        f.write generate
+      file_path = Rails.root.join(file_name)
+      js_content = generate
+
+      # We don't need to rewrite file if it already exist and have same content.
+      # It helps asset pipeline or webpack understand that file wasn't changed.
+      return if File.exist?(file_path) && File.read(file_path) == js_content
+
+      File.open(file_path, 'w') do |f|
+        f.write js_content
       end
     end
   end

--- a/spec/js_routes/zzz_last_post_rails_init_spec.rb
+++ b/spec/js_routes/zzz_last_post_rails_init_spec.rb
@@ -43,6 +43,20 @@ describe "after Rails initialization" do
     expect(File.exists?(NAME)).to be_truthy
   end
 
+  it "should not rewrite routes file if nothing changed" do
+    routes_file_mtime = File.mtime(NAME)
+    JsRoutes.generate!(NAME)
+    expect(File.mtime(NAME)).to eq(routes_file_mtime)
+  end
+
+  it "should rewrite routes file if file content changed" do
+    # Change content of existed routes file (add space to the end of file).
+    File.open(NAME, 'a') { |f| f << ' ' }
+    routes_file_mtime = File.mtime(NAME)
+    JsRoutes.generate!(NAME)
+    expect(File.mtime(NAME)).not_to eq(routes_file_mtime)
+  end
+
   context "JsRoutes::Engine" do
     TEST_ASSET_PATH = Rails.root.join('app','assets','javascripts','test.js')
 


### PR DESCRIPTION
Generating `routes.js` file using rake task rewrites it completely each time. So, asset pipeline or webpacker would recompile assets in case when content wasn't changed (because mtime of `routes.js` was changed).

This PR just skip write to output file, if file already exist and have same content. This way mtime became unchanged and asset pipeline or webpacker properly skip assets recompile.

Mostly same as https://github.com/fnando/i18n-js/pull/473 that solved same problem for `i18n-js` gem.