### PR TITLE
URI-encode route parts

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -281,7 +281,7 @@ Based on Rails routes of APP_CLASS
           value = parameters[left];
           if (value != null) {
             delete parameters[left];
-            return this.path_identifier(value);
+            return encodeURIComponent(this.path_identifier(value));
           }
           if (optional) {
             return "";
@@ -334,7 +334,7 @@ Based on Rails routes of APP_CLASS
       if (value == null) {
         return this.visit(route, parameters, optional);
       }
-      parameters[left] = (function() {
+      value = (function() {
         switch (this.get_object_type(value)) {
           case "array":
             return value.join("/");
@@ -342,7 +342,8 @@ Based on Rails routes of APP_CLASS
             return value;
         }
       }).call(this);
-      return this.visit(route, parameters, optional);
+      delete parameters[left];
+      return this.path_identifier(value);
     },
     get_prefix: function() {
       var prefix;

--- a/lib/routes.js.coffee
+++ b/lib/routes.js.coffee
@@ -212,7 +212,7 @@ Utils =
         value = parameters[left]
         if value?
           delete parameters[left]
-          return @path_identifier(value)
+          return encodeURIComponent(@path_identifier(value))
         if optional
           "" # missing parameter
         else
@@ -260,12 +260,14 @@ Utils =
     route[1] = left = left.replace(/^\*/i, "") if left.replace(/^\*/i, "") isnt left
     value = parameters[left]
     return @visit(route, parameters, optional) unless value?
-    parameters[left] = switch @get_object_type(value)
+    value = switch @get_object_type(value)
       when "array"
         value.join("/")
       else
         value
-    @visit route, parameters, optional
+
+    delete parameters[left]
+    @path_identifier(value)
 
   #
   # This method check and return prefix from options

--- a/spec/js_routes/rails_routes_compatibility_spec.rb
+++ b/spec/js_routes/rails_routes_compatibility_spec.rb
@@ -111,6 +111,9 @@ describe JsRoutes, "compatibility with Rails"  do
     it "should support route with parameters" do
       expect(evaljs("Routes.blog_app_post_path(1)")).to eq(blog_routes.post_path(1))
     end
+    it "should support route with parameters containing symbols that need URI-encoding" do
+      expect(evaljs("Routes.blog_app_post_path('#hello')")).to eq(blog_routes.post_path('#hello'))
+    end
     it "should support root path" do
       expect(evaljs("Routes.blog_app_root_path()")).to eq(blog_routes.root_path)
     end


### PR DESCRIPTION
Resolves https://github.com/railsware/js-routes/issues/243

@le0pard Thanks for replying to the issue 👍 I played a bit around with this and got the specs passing.

If you ask me, the changes I'm proposing here are breaking changes, requiring bumping the major version. This change will actually break my usage of `js-routes` because I'm doing the URI-encoding myself and then passing it into the generated route functions. That way I would end up with URI-encoding twice.

Alternatively this change could be configured with a new config option (which is disabled by default).

Happy to hear what y'all think :v: