### PR TITLE
Use next, not return in after_initialize block

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -146,7 +146,7 @@ class JsRoutes
 
       # We don't need to rewrite file if it already exist and have same content.
       # It helps asset pipeline or webpack understand that file wasn't changed.
-      return if File.exist?(file_path) && File.read(file_path) == js_content
+      next if File.exist?(file_path) && File.read(file_path) == js_content
 
       File.open(file_path, 'w') do |f|
         f.write js_content


### PR DESCRIPTION
**What** Fix a `LocalJumpError` I get when on the second launch of my app

**What's the bug**

Using return inside a block can lead to a `LocalJumpError` if the
block is invoked later instead of immediately. This [stack overflow has a few more details](https://stackoverflow.com/questions/2325471/using-return-in-a-ruby-block)

<details><summary>Simple Proof of Concept</summary><p>

```
$callbacks = []
$initialized = false
def after_initialize(&block)
  if $initialized
    p [:yield]
    block.call
  else
    $callbacks << block
  end
end

def finalize
  $callbacks.each(&:call)
  $initialized = true
end

def set_callback
  after_initialize do
    return
  end
end
```
```
# called in this order it goes boom
set_callback
finalize
```

```
# called in this order it works
finalize
set_callback
```
</p></details>

The tests for this change passed because the rails app is already initialized (in the before all block in the test file) so `after_initialize` is invoked immediately. In my app, the `after_initialize` hook is invoked later on in the boot process so that the `return` doesn't make sense anymore

**What's the fix?**

Use `next` instead of `return`. It has the exact same behaviour, but it's safe no matter where the block is executed