### PR TITLE
Add safe check for 'window' to support server rendering

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -16,6 +16,7 @@ RubyVariables.WRAPPER((that) => {
         NodeTypes[NodeTypes["DOT"] = 8] = "DOT";
     })(NodeTypes || (NodeTypes = {}));
     const Root = that;
+    const isBroswer = typeof window !== "undefined";
     const ModuleReferences = {
         CJS: {
             define(routes) {
@@ -419,15 +420,15 @@ RubyVariables.WRAPPER((that) => {
         }
         current_host() {
             var _a;
-            return ((_a = window === null || window === void 0 ? void 0 : window.location) === null || _a === void 0 ? void 0 : _a.hostname) || "";
+            return (isBroswer && ((_a = window === null || window === void 0 ? void 0 : window.location) === null || _a === void 0 ? void 0 : _a.hostname)) || "";
         }
         current_protocol() {
             var _a, _b;
-            return ((_b = (_a = window === null || window === void 0 ? void 0 : window.location) === null || _a === void 0 ? void 0 : _a.protocol) === null || _b === void 0 ? void 0 : _b.replace(/:$/, "")) || "http";
+            return ((isBroswer && ((_b = (_a = window === null || window === void 0 ? void 0 : window.location) === null || _a === void 0 ? void 0 : _a.protocol) === null || _b === void 0 ? void 0 : _b.replace(/:$/, ""))) || "http");
         }
         current_port() {
             var _a;
-            return ((_a = window === null || window === void 0 ? void 0 : window.location) === null || _a === void 0 ? void 0 : _a.port) || "";
+            return (isBroswer && ((_a = window === null || window === void 0 ? void 0 : window.location) === null || _a === void 0 ? void 0 : _a.port)) || "";
         }
         is_object(value) {
             return (typeof value === "object" &&

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -129,6 +129,7 @@ RubyVariables.WRAPPER(
     }[keyof RouteNodes];
 
     const Root = that;
+    const isBroswer = typeof window !== "undefined";
     type ModuleDefinition = {
       define: (routes: RouterExposedMethods) => void;
       isSupported: () => boolean;
@@ -625,15 +626,17 @@ RubyVariables.WRAPPER(
       }
 
       current_host(): string {
-        return window?.location?.hostname || "";
+        return (isBroswer && window?.location?.hostname) || "";
       }
 
       current_protocol(): string {
-        return window?.location?.protocol?.replace(/:$/, "") || "http";
+        return (
+          (isBroswer && window?.location?.protocol?.replace(/:$/, "")) || "http"
+        );
       }
 
       current_port(): string {
-        return window?.location?.port || "";
+        return (isBroswer && window?.location?.port) || "";
       }
 
       is_object(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
Without this check an exception is raised when server rendering. This is masked by `evaljs("var window = this;", {force: true})` is spec_helper.rb