### PR TITLE
Use default_url_options as base options hash (#289)

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -205,7 +205,9 @@ RubyVariables.WRAPPER((that) => {
                 throw new Error("Too many parameters provided for path");
             }
             let use_all_parts = args.length > required_params.length;
-            const parts_options = {};
+            const parts_options = {
+                ...this.configuration.default_url_options,
+            };
             for (const key in options) {
                 const value = options[key];
                 if (!hasProp(options, key))

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -349,7 +349,9 @@ RubyVariables.WRAPPER(
           throw new Error("Too many parameters provided for path");
         }
         let use_all_parts = args.length > required_params.length;
-        const parts_options: RouteParameters = {};
+        const parts_options: RouteParameters = {
+          ...this.configuration.default_url_options,
+        };
         for (const key in options) {
           const value = options[key];
           if (!hasProp(options, key)) continue;

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -256,14 +256,14 @@ describe JsRoutes, "options" do
     end
 
     context "with optional and required route parts" do
-      let(:_options) { {:default_url_options => { :optional_locale => "en" } } }
+      let(:_options) { {:default_url_options => { :optional_id => "12" } } }
       it "should use this options to fill the optional parameters" do
-        expect(evaljs("Routes.translated_thing_path(1)")).to eq test_routes.translated_thing_path(1, { optional_locale: "en" })
+        expect(evaljs("Routes.thing_path(1)")).to eq test_routes.thing_path(1, { optional_id: "12" })
       end
 
       context "when passing an irrelevant options object" do
         it "should use this options to fill the optional parameters" do
-          expect(evaljs("Routes.translated_thing_path(1, { format: 'json' })")).to eq test_routes.translated_thing_path(1, { optional_locale: "en", format: "json" } )
+          expect(evaljs("Routes.thing_path(1, { format: 'json' })")).to eq test_routes.thing_path(1, { optional_id: "12", format: "json" } )
         end
       end
     end

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -240,6 +240,13 @@ describe JsRoutes, "options" do
         end
       end
 
+      context "provided inline by the method parameters" do
+        let(:options) { { :default_url_options => { :optional_id => "12" } } }
+        it "should overwrite the default_url_options" do
+          expect(evaljs("Routes.things_path({ optional_id: 34 })")).to eq(test_routes.things_path(optional_id: 34))
+        end
+      end
+
       context "not provided" do
         let(:_options) { { :default_url_options => { :format => "json" } } }
         it "breaks" do

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -261,7 +261,7 @@ describe JsRoutes, "options" do
         expect(evaljs("Routes.thing_path(1)")).to eq test_routes.thing_path(1, { optional_id: "12" })
       end
 
-      context "when passing an irrelevant options object" do
+      context "when passing options that do not have defaults" do
         it "should use this options to fill the optional parameters" do
           expect(evaljs("Routes.thing_path(1, { format: 'json' })")).to eq test_routes.thing_path(1, { optional_id: "12", format: "json" } )
         end

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -233,10 +233,10 @@ describe JsRoutes, "options" do
 
   describe "default_url_options" do
     context "with optional route parts" do
-      context "provided" do
+      context "provided by the default_url_options" do
         let(:_options) { { :default_url_options => { :optional_id => "12", :format => "json" } } }
-        it "should use this opions to fill optional parameters" do
-          expect(evaljs("Routes.things_path()")).to eq(test_routes.things_path)
+        it "should use this options to fill optional parameters" do
+          expect(evaljs("Routes.things_path()")).to eq(test_routes.things_path(12))
         end
       end
 
@@ -249,9 +249,22 @@ describe JsRoutes, "options" do
     end
 
     context "with required route parts" do
-      let(:_options) { {:default_url_options => {:inbox_id => "12"}} }
-      it "should use this opions to fill optional parameters" do
+      let(:_options) { { :default_url_options => { :inbox_id => "12" } } }
+      it "should use this options to fill optional parameters" do
         expect(evaljs("Routes.inbox_messages_path()")).to eq(test_routes.inbox_messages_path)
+      end
+    end
+
+    context "with optional and required route parts" do
+      let(:_options) { {:default_url_options => { :optional_locale => "en" } } }
+      it "should use this options to fill the optional parameters" do
+        expect(evaljs("Routes.translated_thing_path(1)")).to eq test_routes.translated_thing_path(1, { optional_locale: "en" })
+      end
+
+      context "when passing an irrelevant options object" do
+        it "should use this options to fill the optional parameters" do
+          expect(evaljs("Routes.translated_thing_path(1, { format: 'json' })")).to eq test_routes.translated_thing_path(1, { optional_locale: "en", format: "json" } )
+        end
       end
     end
 

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -263,7 +263,7 @@ describe JsRoutes, "options" do
 
       context "when passing options that do not have defaults" do
         it "should use this options to fill the optional parameters" do
-          expect(evaljs("Routes.thing_path(1, { format: 'json' })")).to eq test_routes.thing_path(1, { optional_id: "12", format: "json" } )
+          expect(evaljs("Routes.thing_path(1, { format: 'json' })")).to eq test_routes.thing_path(1, { optional_id: "12", format: "json" } ) # test_routes.thing_path needs optional_id here to generate the correct route. Not sure why.
         end
       end
     end

--- a/spec/support/routes.rb
+++ b/spec/support/routes.rb
@@ -36,10 +36,6 @@ def draw_routes
       resources :things, only: [:show, :index]
     end
 
-    scope "(:optional_locale)" do
-      resources :translated_things, only: [:show]
-    end
-
     get "(/sep1/:first_optional)/sep2/:second_required/sep3/:third_required(/:forth_optional)",
       as: :thing_deep, controller: :things, action: :show
 

--- a/spec/support/routes.rb
+++ b/spec/support/routes.rb
@@ -36,6 +36,10 @@ def draw_routes
       resources :things, only: [:show, :index]
     end
 
+    scope "(:optional_locale)" do
+      resources :translated_things, only: [:show]
+    end
+
     get "(/sep1/:first_optional)/sep2/:second_required/sep3/:third_required(/:forth_optional)",
       as: :thing_deep, controller: :things, action: :show
 


### PR DESCRIPTION
Uses `default_url_options` configuration option as the basis to then overwrite with the options hash passed in the context of partitioning the parameters.

Please let me know if you see any improvements I can make!

Thanks again for all your effort!