### PR TITLE
Add GitHub actions for status badge to README.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,7 @@
 # JsRoutes
 
+[![CI](https://github.com/railsware/js-routes/actions/workflows/ci.yml/badge.svg)](https://github.com/railsware/js-routes/actions/workflows/ci.yml)
+
 Generates javascript file that defines all Rails named routes as javascript helpers
 
 ## Intallation


### PR DESCRIPTION
This PR is to add a status badge to display the results of a GitHub action.

How about this PR?

### Test

I have confirmed that the Github Action result badge appears in my repository.

https://github.com/madogiwa0124/js-routes/blob/c6429e12388707895cda444e36745824dc1bcffc/Readme.md