### PR TITLE
Add post_processor to customize the output of each route

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -302,7 +302,9 @@ Options to configure JavaScript file generator. These options are only available
   * Default: `Rails.application`
 * `file` - a file location where generated routes are stored
   * Default: `app/javascript/routes.js` if setup with Webpacker, otherwise `app/assets/javascripts/routes.js` if setup with Sprockets.
-
+* `post_processor` - a proc that takes a string and returns a string. It is called after the each route is generated and can be used to modify the generated code.
+  * Default: `nil`
+  * Example: `->(code) { code + addition }`
 <div id="formatter-options"></div>
 
 #### Formatter Options

--- a/lib/js_routes/configuration.rb
+++ b/lib/js_routes/configuration.rb
@@ -17,6 +17,7 @@ module JsRoutes
       application: -> { Rails.application },
       module_type: 'ESM',
       documentation: true,
+      post_processor: nil,
     } #:nodoc:
 
     attr_accessor(*DEFAULTS.keys)
@@ -32,9 +33,10 @@ module JsRoutes
         raise "Provide attributes or block"
       end
       tap(&block) if block
+      no_instant_call_attributes = [:post_processor]
       if attributes
         attributes.each do |attribute, value|
-          value = value.call if value.is_a?(Proc)
+          value = value.call if value.is_a?(Proc) && !no_instant_call_attributes.include?(attribute)
           send(:"#{attribute}=", value)
         end
       end

--- a/lib/js_routes/instance.rb
+++ b/lib/js_routes/instance.rb
@@ -112,15 +112,21 @@ module JsRoutes
           "", name,
           @configuration.dts? ?
           "RouterExposedMethods['#{name}']" :
-          "__jsr.#{name}"
+          "__jsr.#{name}",
+          nil
         ]
       end
     end
 
+    def post_process(content, route)
+      @configuration.post_processor ? @configuration.post_processor.call(content, route) : content
+    end
+
     def routes_export
       return "" unless @configuration.modern?
-      [*static_exports, *routes_list].map do |comment, name, body|
-        "#{comment}export const #{name}#{export_separator}#{body};\n\n"
+      [*static_exports, *routes_list].map do |comment, name, body, route|
+        content = "#{comment}export const #{name}#{export_separator}#{body};\n\n"
+        post_process(content, route)
       end.join
     end
 

--- a/lib/js_routes/instance.rb
+++ b/lib/js_routes/instance.rb
@@ -100,8 +100,8 @@ module JsRoutes
 
     def routes_object
       return json({}) if @configuration.modern?
-      properties = routes_list.map do |comment, name, body|
-        "#{comment}#{name}: #{body}".indent(2)
+      properties = routes_list.map do |comment, name, body, route|
+        post_process("#{comment}#{name}: #{body}", route).indent(2)
       end
       "{\n" + properties.join(",\n\n") + "}\n"
     end

--- a/lib/js_routes/route.rb
+++ b/lib/js_routes/route.rb
@@ -23,7 +23,7 @@ module JsRoutes
 
     def helpers
       helper_types.map do |absolute|
-        [ documentation, helper_name(absolute), body(absolute) ]
+        [ documentation, helper_name(absolute), body(absolute), @route ]
       end
     end
 

--- a/spec/js_routes/module_types/dts_spec.rb
+++ b/spec/js_routes/module_types/dts_spec.rb
@@ -108,4 +108,26 @@ DOC
       is_expected.to include("export const inbox_message_path = __jsr.r(")
     end
   end
+
+  context do
+    let(:post_processor) do
+      Proc.new do |content, route|
+        if route
+          pattern = route.path.spec.to_s.gsub('(.:format)', '').gsub('.:format', '')
+          content + %Q[\nexport const #{route.name}_pattern = '#{pattern}';\n\n]
+        else
+          content
+        end
+      end
+    end
+
+    let(:generated_js) do
+      JsRoutes.generate(**OPTIONS.merge(post_processor: post_processor), **extra_options)
+    end
+
+    it "exports route helpers" do
+      expect(generated_js).to include("export const inboxes_pattern = '/inboxes';")
+      expect(generated_js).to include("export const inbox_message_attachment_pattern = '/inboxes/:inbox_id/messages/:message_id/attachments/:id';")
+    end
+  end
 end

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -505,4 +505,23 @@ describe JsRoutes, "options" do
       expect(generated_js).not_to include("@returns")
     end
   end
+
+  describe "post_processor option" do
+    let(:post_processor) do
+      Proc.new do |content, route|
+        if route
+          pattern = route.path.spec.to_s.gsub('(.:format)', '').gsub('.:format', '')
+          content + %Q[,\n#{route.name}_pattern: '#{pattern}']
+        else
+          content
+        end
+      end
+    end
+    let(:_options) { {post_processor: post_processor} }
+
+    it "disables documentation generation" do
+      expect(generated_js).to include("inboxes_pattern: '/inboxes',")
+      expect(generated_js).to include("inbox_message_attachment_pattern: '/inboxes/:inbox_id/messages/:message_id/attachments/:id',")
+    end
+  end
 end


### PR DESCRIPTION
Sometimes we need to customize the output of each individual route.

I was faced with the task of typing routes when used with react. And I couldn't use dynamic generated routes with toString(). This method returns `string` type for any helper. It would be great for me if it was possible to export patterns as literals