### PR TITLE
fix: rename `File.exists?` to `File.exist?`

### DIFF
--- a/lib/js_routes/generators/base.rb
+++ b/lib/js_routes/generators/base.rb
@@ -10,7 +10,7 @@ class JsRoutes::Generators::Base < Rails::Generators::Base
       "app/javascript/packs/application.js",
       "app/javascript/controllers/application.js",
     ].find do |path|
-      File.exists?(Rails.root.join(path))
+      File.exist?(Rails.root.join(path))
     end
   end
 end

--- a/spec/js_routes/module_types/umd_spec.rb
+++ b/spec/js_routes/module_types/umd_spec.rb
@@ -79,7 +79,7 @@ DOC
     end
 
     it "should not generate file before initialization" do
-      expect(File.exists?(name)).to be_falsey
+      expect(File.exist?(name)).to be_falsey
     end
   end
 end

--- a/spec/js_routes/zzz_last_post_rails_init_spec.rb
+++ b/spec/js_routes/zzz_last_post_rails_init_spec.rb
@@ -47,7 +47,7 @@ describe "after Rails initialization", :slow do
   end
 
   it "should generate routes file" do
-    expect(File.exists?(NAME)).to be_truthy
+    expect(File.exist?(NAME)).to be_truthy
   end
 
   it "should not rewrite routes file if nothing changed" do


### PR DESCRIPTION
The deprecated `File.exists?` alias was removed on Ruby 3.2.0.

`File.exist?` works on all versions.

ref: https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/