### PR TITLE
Fix broken configuration when module_type is Nil and namespace is being used.

### DIFF
--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -57,7 +57,7 @@ module JsRoutes
 
     sig { returns(T.nilable(String)) }
     def default_module_type
-      'DTS' if configuration.module_type
+      'DTS' if configuration.module_type && configuration.module_type != 'NIL'
     end
 
 

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -41,19 +41,26 @@ module JsRoutes
 
     sig { params(opts: T.untyped).returns(String) }
     def definitions(**opts)
-      generate(**opts, module_type: 'DTS',)
+      generate(**opts, module_type: default_module_type,)
     end
 
     sig { params(file_name: FileName, opts: T.untyped).void }
     def definitions!(file_name = nil, **opts)
       file_name ||= configuration.file&.sub(%r{(\.d)?\.(j|t)s\Z}, ".d.ts")
-      generate!(file_name, **opts, module_type: 'DTS')
+      generate!(file_name, **opts, module_type: default_module_type)
     end
 
     sig { params(value: T.untyped).returns(String) }
     def json(value)
       ActiveSupport::JSON.encode(value)
     end
+
+    sig { returns(T.nilable(String)) }
+    def default_module_type
+      'DTS' if configuration.module_type
+    end
+
+
   end
   module Generators
   end

--- a/spec/js_routes/module_types/dts_spec.rb
+++ b/spec/js_routes/module_types/dts_spec.rb
@@ -122,5 +122,15 @@ DOC
       generated_js = JsRoutes.definitions(**options)
       expect(generated_js).to include('export {};')
     end
+
+    it 'does not use DTS module if module_type is not set' do
+      previous_module_type = JsRoutes.configuration.module_type
+      JsRoutes.configuration.module_type = nil
+
+      generated_js = JsRoutes.definitions(**options.merge(module_type: nil))
+      expect(generated_js).not_to include('export {};')
+
+      JsRoutes.configuration.module_type = previous_module_type
+    end
   end
 end


### PR DESCRIPTION
Hi!

I have a simple project that doesn't use any import/export modules and is still using sprockets. 
On latest version, if I have this configuration:

```ruby
JsRoutes.setup do |c|
  c.module_type = nil
  c.namespace = 'Routes'
end
```

It breaks like this when I load any endpoint:

<img width="1000" alt="image" src="https://github.com/user-attachments/assets/e7600818-ac9b-4aa9-ad4e-c01d8d8da8f8">

After reviewing, I noticed that 'DTS' was being used by default causing this clash. I solved it by monkey patching it on my project, but I thought I would suggest this modification to support the intended behavior of prioritizing DTS only if the configuration_type has not been set.