### PR TITLE
Fix NoMethodError when run js:routes:typescript

### DIFF
--- a/lib/tasks/js_routes.rake
+++ b/lib/tasks/js_routes.rake
@@ -8,7 +8,7 @@ namespace :js do
   namespace :routes do
     desc "Make a js file with all rails route URL helpers and typescript definitions for them"
     task typescript: "js:routes" do
-      ActiveSupport::Deprecation.warn(
+      ActiveSupport::Deprecation.new.warn(
         "`js:routes:typescript` task is deprecated. Please use `js:routes` instead."
       )
     end


### PR DESCRIPTION
`js:routes:typescript` raise below error.

```
rake aborted!
NoMethodError: private method `warn' called for class ActiveSupport::Deprecation (NoMethodError)

      ActiveSupport::Deprecation.warn(
                                ^^^^^
/vendor/bundle/ruby/3.3.0/gems/js-routes-2.3.3/lib/tasks/js_routes.rake:11:in `block (3 levels) in <main>'
Tasks: TOP => js:routes:typescript
(See full trace by running task with --trace)
```

Because ActiveSupport::Deprecation.warn was removed from Rails 7.2.