### PR TITLE
Add `package` and `package_file` options

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -240,6 +240,29 @@ which will cause any `JsRoutes` instance to generate defintions instead of route
 
 <div id="sprockets"></div>
 
+#### Splitting routes into multiple files with shared package (`ESM` only)
+
+Some setups may benefit from splitting routes into multiple files with the core js-routes utils shared between these files. This can be helpful for codebases that have a large number of routes and can improve tree shaking. This is only available when the `module_type` is set to `ESM`.
+
+```ruby
+class AdvancedJsRoutesMiddleware < JsRoutes::Middleware
+  def regenerate
+    JsRoutes.generate_package!
+
+    JsRoutes.generate!(
+      "admin_routes.js",
+      include: /^admin_/,
+      package: './routes_core.js'
+    )
+    JsRoutes.generate!(
+      "api_routes.js",
+      include: /^api_/,
+      package: './routes_core.js'
+    )
+  end
+end
+```
+
 ### Sprockets (Deprecated)
 
 If you are using [Sprockets](https://github.com/rails/sprockets-rails) you may configure js-routes in the following way.
@@ -328,6 +351,12 @@ Options to configure JavaScript file generator. These options are only available
   * Default: `-> { Rails.application }`
 * `file` - a file location where generated routes are stored
   * Default: `app/javascript/routes.js` if setup with Webpacker, otherwise `app/assets/javascripts/routes.js` if setup with Sprockets.
+* `package_file` - a file location where generated shared package will be stored.
+  * Default: `app/javascript/routes_core.js` if setup with Webpacker, otherwise `app/assets/javascripts/routes_core.js` if setup with Sprockets.
+* `package` - specify where the shared package will be imported from. e.g. `'./routes_core.js'`.
+  * Generate the shared package with `generate_package!`.
+  * See [Splitting routes into multiple files with shared package](#splitting-routes-into-multiple-files-with-shared-package-esm-only).
+  * Default: `nil`
 * `optional_definition_params` - make all route paramters in definition optional
   * See [related compatibility issue](#optional-definition-params)
   * Default: `false`

--- a/lib/js_routes.rb
+++ b/lib/js_routes.rb
@@ -44,6 +44,17 @@ module JsRoutes
       end
     end
 
+    sig { params(opts: T.untyped).returns(String) }
+    def generate_package(**opts)
+      Instance.new(**opts).generate_package
+    end
+
+    sig { params(file_name: FileName, typed: T::Boolean, opts: T.untyped).void }
+    def generate_package!(file_name = configuration.package_file, typed: false, **opts)
+      instance = Instance.new(file: file_name, **opts)
+      instance.generate_package!
+    end
+
     sig { params(file_name: FileName, opts: T.untyped).void }
     def remove!(file_name = configuration.file, **opts)
       Instance.new(file: file_name, **opts).remove!

--- a/lib/js_routes/configuration.rb
+++ b/lib/js_routes/configuration.rb
@@ -18,6 +18,10 @@ module JsRoutes
     attr_accessor :include
     sig { returns(FileName) }
     attr_accessor :file
+    sig { returns(FileName) }
+    attr_accessor :package_file
+    sig { returns(T.nilable(String)) }
+    attr_accessor :package
     sig { returns(Prefix) }
     attr_reader :prefix
     sig { returns(T::Boolean) }
@@ -61,6 +65,7 @@ module JsRoutes
       @documentation = T.let(true, T::Boolean)
       @optional_definition_params = T.let(false, T::Boolean)
       @banner = T.let(default_banner, BannerCaller)
+      @package = T.let(nil, T.nilable(String))
 
       return unless attributes
       assign(attributes)
@@ -116,6 +121,10 @@ module JsRoutes
       esm? || dts?
     end
 
+    def package_mode?
+      esm? && package
+    end
+
     sig { void }
     def require_esm
       raise "ESM module type is required" unless modern?
@@ -128,17 +137,26 @@ module JsRoutes
 
     sig { returns(Pathname) }
     def output_file
+      output_file_path(file || default_file_name)
+    end
+
+    sig { returns(Pathname) }
+    def output_package_file
+      output_file_path(package_file || 'routes_core.js')
+    end
+
+    protected
+
+    sig { params(file_name: FileName).returns(Pathname) }
+    def output_file_path(file_name)
       shakapacker = JsRoutes::Utils.shakapacker
       shakapacker_dir = shakapacker ?
         shakapacker.config.source_path : pathname('app', 'javascript')
       sprockets_dir = pathname('app','assets','javascripts')
-      file_name = file || default_file_name
       sprockets_file = sprockets_dir.join(file_name)
       webpacker_file = shakapacker_dir.join(file_name)
       !Dir.exist?(shakapacker_dir) && defined?(::Sprockets) ? sprockets_file : webpacker_file
     end
-
-    protected
 
     sig { void }
     def normalize_and_verify

--- a/lib/js_routes/instance.rb
+++ b/lib/js_routes/instance.rb
@@ -35,15 +35,27 @@ module JsRoutes
           end
         end
       end
-      content = File.read(@configuration.source_file)
 
-      unless @configuration.dts?
-        content = js_variables.inject(content) do |js, (key, value)|
-          js.gsub!("RubyVariables.#{key}", value.to_s) ||
-          raise("Missing key #{key} in JS template")
-        end
+      if @configuration.package_mode?
+        content = "import { __jsr } from '#{@configuration.package}';\n\n"
+      else
+        content = jsr
       end
+
       banner + content + routes_export + prevent_types_export
+    end
+
+    sig {returns(String)}
+    def generate_package
+      return '' unless @configuration.esm?
+
+      exports = static_exports.map do |comment, name, body|
+        "export const #{name}#{export_separator}#{body};\n\n"
+      end.join
+
+      exports << "\n\nexport { __jsr };"
+
+      jsr + exports
     end
 
     sig { returns(String) }
@@ -79,13 +91,44 @@ module JsRoutes
     end
 
     sig { void }
+    def generate_package!
+      return unless @configuration.esm?
+
+      file_path = Rails.root.join(@configuration.output_package_file)
+      source_code = generate_package
+
+      # We don't need to rewrite file if it already exist and have same content.
+      # It helps asset pipeline or webpack understand that file wasn't changed.
+      return if File.exist?(file_path) && File.read(file_path) == source_code
+
+      File.open(file_path, 'w') do |f|
+        f.write source_code
+      end
+    end
+
+    sig { void }
     def remove!
       path = Rails.root.join(@configuration.output_file)
+      package_path = Rails.root.join(@configuration.output_package_file)
       FileUtils.rm_rf(path)
+      FileUtils.rm_rf(package_path)
       FileUtils.rm_rf(path.sub(%r{\.js\z}, '.d.ts'))
     end
 
     protected
+
+    def jsr
+      content = File.read(@configuration.source_file)
+
+      unless @configuration.dts?
+        content = js_variables.inject(content) do |js, (key, value)|
+          js.gsub!("RubyVariables.#{key}", value.to_s) ||
+          raise("Missing key #{key} in JS template")
+        end
+      end
+
+      content
+    end
 
     sig { returns(T::Hash[String, String]) }
     def js_variables

--- a/spec/js_routes/module_types/esm_spec.rb
+++ b/spec/js_routes/module_types/esm_spec.rb
@@ -2,7 +2,6 @@ require "active_support/core_ext/string/strip"
 require "spec_helper"
 
 describe JsRoutes, "compatibility with ESM"  do
-
   let(:generated_js) {
     JsRoutes.generate(module_type: 'ESM', include: /\Ainbox/)
   }
@@ -40,6 +39,45 @@ DOC
     subject { ERB.new(File.read("app/assets/javascripts/js-routes.js.erb")).result(binding) }
     it "should have js routes code" do
       is_expected.to include("export const inbox_message_path = /*#__PURE__*/ __jsr.r(")
+    end
+  end
+end
+
+describe JsRoutes, "compatibility with ESM using the package argument" do
+  describe '.generate_package' do
+    let(:generated_package) {
+      JsRoutes.generate_package(module_type: 'ESM')
+    }
+
+    it 'generates package with __jsr export' do
+      expect(generated_package).to include("export { __jsr };")
+    end
+  end
+
+  describe '.generate' do
+    let(:generated_js) {
+      JsRoutes.generate(module_type: 'ESM', package: './routes_core.js', include: /\Ainbox/)
+    }
+
+    it "imports __jsr from package" do
+      expect(generated_js).to include("import { __jsr } from './routes_core.js';")
+    end
+  end
+
+  describe '.generate_package!' do
+    let(:path) { Rails.root.join('app', 'assets', 'javascripts', 'routes_core.js') }
+    let(:generated_package) {
+      JsRoutes.generate_package!(module_type: 'ESM')
+
+      File.read(path)
+    }
+
+    after(:each) do
+      JsRoutes.remove!
+    end
+
+    it "should generate package file" do
+      expect(generated_package).to include("export { __jsr };")
     end
   end
 end

--- a/spec/js_routes/module_types/umd_spec.rb
+++ b/spec/js_routes/module_types/umd_spec.rb
@@ -82,4 +82,29 @@ DOC
       expect(File.exist?(name)).to be_falsey
     end
   end
+
+  describe '.generate_package' do
+    let(:generated_package) {
+      JsRoutes.generate_package(module_type: 'UMD')
+    }
+
+    it 'returns empty string' do
+      expect(generated_package).to eq ''
+    end
+  end
+
+  describe '.generate_package!' do
+    let(:path) { Rails.root.join('app', 'assets', 'javascripts', 'routes_core.js') }
+    let(:generated_package) {
+      JsRoutes.generate_package!(module_type: 'UMD')
+    }
+
+    after(:each) do
+      JsRoutes.remove!
+    end
+
+    it "should not generate package file" do
+      expect(File.exist?(path)).to be_falsey
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,7 +41,7 @@ def js_error_class
   end
 end
 
-def evaljs(string, force: false, filename: 'context.js')
+def evaljs(string, force: false, filename: 'context.mjs')
   jscontext(force).eval(string, filename: filename)
 rescue MiniRacer::ParseError => e
   trace = e.message


### PR DESCRIPTION
Closes https://github.com/railsware/js-routes/issues/339

Adds more flexibility to split routes into multiple files with a shared package imported between them. This can improve tree shaking for codebases with a large number of routes. See example in docs (in this PR) and https://github.com/railsware/js-routes/issues/339#issuecomment-3783525416 for more context