### PR TITLE
Add configurable output path to middleware generator

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,14 @@ to automatically generate and maintain `routes.js` file and corresponding
 Run a command:
 
 ``` sh
+# Default location (app/javascript/routes.js)
 rails generate js_routes:middleware
+
+# Custom output directory — generates app/frontend/routes.js
+rails generate js_routes:middleware app/frontend
+
+# Custom full path
+rails generate js_routes:middleware app/frontend/my_routes.js
 ```
 
 #### Setup Manually
@@ -351,7 +358,9 @@ Options to configure JavaScript file generator. These options are only available
   * This option allows to only generate routes for a specific rails engine, that is mounted into routes instead of all Rails app routes
   * It is recommended to wrap the value with `lambda`. This will reduce the reliance on order during initialization your application.
   * Default: `-> { Rails.application }`
-* `file` - a file location where generated routes are stored
+* `file` - output location for the generated routes file, relative to Rails root
+  * Accepts a **directory** (`"app/frontend"`) or a **full path** (`"app/frontend/routes.js"`).
+    A directory automatically resolves to `<dir>/routes.js` (or `routes.d.ts` for TypeScript definitions).
   * Default: `app/javascript/routes.js` if setup with Webpacker, otherwise `app/assets/javascripts/routes.js` if setup with Sprockets.
 * `package` - specify where the shared package will be imported from. e.g. `'./router.js'`.
   * Generate the shared package with `package!`.

--- a/lib/js_routes/configuration.rb
+++ b/lib/js_routes/configuration.rb
@@ -1,9 +1,8 @@
 # typed: strict
 
-require "pathname"
 require "js_routes/types"
-require 'js_routes/utils'
-require 'js_routes/version'
+require "js_routes/utils"
+require "js_routes/version"
 
 module JsRoutes
   class Configuration
@@ -22,7 +21,11 @@ module JsRoutes
     attr_reader :package
 
     def package=(value)
-      @package = value == true ? "./router.js" : (value == false ? nil : value)
+      @package = if value == true
+        "./router.js"
+      else
+        ((value == false) ? nil : value)
+      end
     end
     sig { returns(Prefix) }
     attr_reader :prefix
@@ -53,7 +56,7 @@ module JsRoutes
     sig { returns(T::Boolean) }
     attr_accessor :deprecated_nil_query_parameter_behavior
 
-    sig {params(attributes: T.nilable(Options)).void }
+    sig { params(attributes: T.nilable(Options)).void }
     def initialize(attributes = nil)
       @namespace = nil
       @exclude = T.let([], Clusivity)
@@ -67,13 +70,13 @@ module JsRoutes
       @serializer = T.let(nil, T.nilable(String))
       @special_options_key = T.let("_options", Literal)
       @application = T.let(T.unsafe(-> { Rails.application }), ApplicationCaller)
-      @module_type = T.let('ESM', T.nilable(String))
+      @module_type = T.let("ESM", T.nilable(String))
       @documentation = T.let(true, T::Boolean)
       @optional_definition_params = T.let(false, T::Boolean)
       @banner = T.let(default_banner, BannerCaller)
       @package = T.let(nil, T.nilable(String))
-      @deprecated_false_parameter_behavior = T.let(defined?(Rails) ? Rails.version < '7.0.0' : false, T::Boolean)
-      @deprecated_nil_query_parameter_behavior = T.let(defined?(Rails) ? Rails.version < '8.1.0' : false, T::Boolean)
+      @deprecated_false_parameter_behavior = T.let(defined?(Rails) ? Rails.version < "7.0.0" : false, T::Boolean)
+      @deprecated_nil_query_parameter_behavior = T.let(defined?(Rails) ? Rails.version < "8.1.0" : false, T::Boolean)
 
       return unless attributes
       assign(attributes)
@@ -81,7 +84,7 @@ module JsRoutes
 
     sig do
       params(
-        attributes: Options,
+        attributes: Options
       ).returns(JsRoutes::Configuration)
     end
     def assign(attributes)
@@ -114,22 +117,22 @@ module JsRoutes
       clone.assign(attributes)
     end
 
-    sig {returns(T::Boolean)}
+    sig { returns(T::Boolean) }
     def esm?
-      module_type === 'ESM'
+      module_type === "ESM"
     end
 
-    sig {returns(T::Boolean)}
+    sig { returns(T::Boolean) }
     def dts?
-      self.module_type === 'DTS'
+      module_type === "DTS"
     end
 
-    sig {returns(T::Boolean)}
+    sig { returns(T::Boolean) }
     def pkg?
-      module_type === 'PKG'
+      module_type === "PKG"
     end
 
-    sig {returns(T::Boolean)}
+    sig { returns(T::Boolean) }
     def modern?
       esm? || dts?
     end
@@ -164,13 +167,19 @@ module JsRoutes
 
     sig { params(file_name: FileName).returns(Pathname) }
     def output_file_path(file_name)
+      file_str = file_name.to_s
+      # No JS/TS extension → treat as a directory, append the default filename
+      file_str = File.join(file_str, default_file_name) unless file_str.end_with?(".js", ".ts")
+      # Has a directory component → use as-is relative to Rails root
+      return Pathname.new(file_str) if File.dirname(file_str) != "."
+
       shakapacker = JsRoutes::Utils.shakapacker
       shakapacker_dir = shakapacker ?
         shakapacker.config.source_path : pathname(self.class.rails_javascript_path)
-      sprockets_dir = pathname('app','assets','javascripts')
-      sprockets_file = sprockets_dir.join(file_name)
-      webpacker_file = shakapacker_dir.join(file_name)
-      !Dir.exist?(shakapacker_dir) && defined?(::Sprockets) ? sprockets_file : webpacker_file
+      sprockets_dir = pathname("app", "assets", "javascripts")
+      sprockets_file = sprockets_dir.join(file_str)
+      webpacker_file = shakapacker_dir.join(file_str)
+      (!Dir.exist?(shakapacker_dir) && defined?(::Sprockets)) ? sprockets_file : webpacker_file
     end
 
     sig { returns(String) }
@@ -198,17 +207,21 @@ module JsRoutes
 
     sig { returns(String) }
     def default_file_name
-      dts? ? "routes.d.ts" : pkg? ? "router.js" : "routes.js"
+      if dts?
+        "routes.d.ts"
+      else
+        pkg? ? "router.js" : "routes.js"
+      end
     end
 
-    sig {void}
+    sig { void }
     def normalize
-      self.module_type = module_type&.upcase || 'NIL'
+      self.module_type = module_type&.upcase || "NIL"
     end
 
     sig { void }
     def verify
-      if module_type != 'NIL' && namespace
+      if module_type != "NIL" && namespace
         raise "JsRoutes namespace option can only be used if module_type is nil"
       end
       if package && !esm?
@@ -218,14 +231,13 @@ module JsRoutes
 
     sig { returns(T.proc.returns(String)) }
     def default_banner
-      -> () {
+      -> {
         app = application.is_a?(Proc) ? T.unsafe(application).call : application
         <<~TXT
           @file Generated by js-routes #{JsRoutes::VERSION}. Based on Rails #{Rails.version} routes of #{app.class}.
           @version #{JsRoutes.digest}
           @see https://github.com/railsware/js-routes
         TXT
-
       }
     end
   end

--- a/lib/js_routes/generators/middleware.rb
+++ b/lib/js_routes/generators/middleware.rb
@@ -1,24 +1,33 @@
 require "js_routes/generators/base"
 
 class JsRoutes::Generators::Middleware < JsRoutes::Generators::Base
+  argument :js_routes_file, type: :string, default: nil, optional: true,
+    desc: "Output directory or file path relative to Rails root. " \
+          "Directory: app/frontend → app/frontend/routes.js. " \
+          "Full path: app/frontend/my_routes.js"
 
   def create_middleware
     copy_file "initializer.rb", "config/initializers/js_routes.rb"
+    if js_routes_file
+      inject_into_file "config/initializers/js_routes.rb",
+        "  c.file = #{js_routes_file.inspect}\n\n",
+        after: "JsRoutes.setup do |c|\n"
+    end
     inject_into_file "config/environments/development.rb", middleware_content, before: /^end\n\z/
     inject_into_file "Rakefile", rakefile_content
     inject_into_file ".gitignore", gitignore_content
     if path = application_js_path
       inject_into_file path, pack_content
     end
-    JsRoutes.generate!(typed: true)
+    JsRoutes.generate!(js_routes_file, typed: true)
   end
 
   protected
 
   def pack_content
-    <<-JS
-import {root_path} from '../routes';
-alert(`JsRoutes installed.\\nYour root path is ${root_path()}`)
+    <<~JS
+      import {root_path} from '../routes';
+      alert(`JsRoutes installed.\\nYour root path is ${root_path()}`)
     JS
   end
 
@@ -33,23 +42,22 @@ alert(`JsRoutes installed.\\nYour root path is ${root_path()}`)
 
   def rakefile_content
     enhanced_task = depends_on_js_bundling? ? "javascript:build" : "assets:precompile"
-    <<-RB
-# Update js-routes file before javascript build
-task "#{enhanced_task}" => "js:routes"
+    <<~RB
+      # Update js-routes file before javascript build
+      task "#{enhanced_task}" => "js:routes"
     RB
   end
 
   def gitignore_content
-    banner = <<-TXT
-
-# Ignore automatically generated js-routes files.
+    banner = <<~TXT
+      
+      # Ignore automatically generated js-routes files.
     TXT
 
-    banner + [
-      {},
-      {module_type: 'DTS'}
-    ].map do |config|
-      File.join('/', JsRoutes::Configuration.new(config).output_file) + "\n"
-    end.join
+    file_option = js_routes_file ? {file: js_routes_file} : {}
+    js_path = JsRoutes::Configuration.new(file_option).output_file.to_s
+    dts_path = js_path.sub(%r{(\.d)?\.(j|t)s\z}, ".d.ts")
+
+    banner + [js_path, dts_path].map { |path| File.join("/", path) + "\n" }.join
   end
 end

--- a/lib/js_routes/instance.rb
+++ b/lib/js_routes/instance.rb
@@ -1,8 +1,9 @@
 # typed: strict
+
 require "js_routes/configuration"
 require "js_routes/route"
 require "js_routes/types"
-require 'fileutils'
+require "fileutils"
 
 module JsRoutes
   class Instance # :nodoc:
@@ -21,7 +22,7 @@ module JsRoutes
       @configuration = T.let(JsRoutes.configuration.merge(options), JsRoutes::Configuration)
     end
 
-    sig {returns(String)}
+    sig { returns(String) }
     def generate
       # Ensure routes are loaded. If they're not, load them.
 
@@ -37,16 +38,15 @@ module JsRoutes
       end
 
       content = jsr
-      unless @configuration.module_type == "NIL"
-        banner + content + routes_export
-      else
+      if @configuration.module_type == "NIL"
         # Strip the empty IMPORT_ROUTER statement (comment + semicolon) left after substitution
         content.sub(/\A(\/\/[^\n]+\n)*;\n/, "")
+      else
+        banner + content + routes_export
       end
-
     end
 
-    sig {returns(String)}
+    sig { returns(String) }
     def package
       raise "Package generation requires module_type: 'PKG'" unless @configuration.pkg?
 
@@ -62,7 +62,7 @@ module JsRoutes
         "/**",
         *banner.split("\n").map { |line| " * #{line}" },
         " */",
-        "",
+        ""
       ].join("\n")
     end
 
@@ -79,9 +79,8 @@ module JsRoutes
         # It helps asset pipeline or webpack understand that file wasn't changed.
         next if File.exist?(file_path) && File.read(file_path) == source_code
 
-        File.open(file_path, 'w') do |f|
-          f.write source_code
-        end
+        FileUtils.mkdir_p(file_path.dirname)
+        File.write(file_path, source_code)
       end
     end
 
@@ -96,16 +95,15 @@ module JsRoutes
       # It helps asset pipeline or webpack understand that file wasn't changed.
       return if File.exist?(file_path) && File.read(file_path) == source_code
 
-      File.open(file_path, 'w') do |f|
-        f.write source_code
-      end
+      FileUtils.mkdir_p(file_path.dirname)
+      File.write(file_path, source_code)
     end
 
     sig { void }
     def remove!
       path = Rails.root.join(@configuration.output_file)
       FileUtils.rm_rf(path)
-      FileUtils.rm_rf(path.sub(%r{\.js\z}, '.d.ts'))
+      FileUtils.rm_rf(path.sub(%r{\.js\z}, ".d.ts"))
     end
 
     protected
@@ -127,7 +125,7 @@ module JsRoutes
 
       js_variables.inject(content) do |js, (key, value)|
         js.gsub!("RubyVariables.#{key}", value.to_s) ||
-        raise("Missing key #{key} in JS template")
+          raise("Missing key #{key} in JS template")
       end
     end
 
@@ -140,26 +138,26 @@ module JsRoutes
       prefix = @configuration.prefix
       prefix = prefix.call if prefix.is_a?(Proc)
       {
-        'ROUTES_OBJECT'       => routes_object,
-        'DEPRECATED_FALSE_PARAMETER_BEHAVIOR' => @configuration.deprecated_false_parameter_behavior,
-        'DEPRECATED_NIL_QUERY_PARAMETER_BEHAVIOR' => @configuration.deprecated_nil_query_parameter_behavior,
-        'DEFAULT_URL_OPTIONS' => json(@configuration.default_url_options),
-        'PREFIX'              => json(prefix),
-        'SPECIAL_OPTIONS_KEY' => json(@configuration.special_options_key),
-        'SERIALIZER'          => @configuration.serializer || json(nil),
-        'MODULE_TYPE'         => json(@configuration.module_type),
-        'WRAPPER'             => wrapper_variable,
-        "IMPORT_ROUTER"       => import_router_variable,
-        "EMBED_ROUTER"        => embed_router_variable,
+        "ROUTES_OBJECT" => routes_object,
+        "DEPRECATED_FALSE_PARAMETER_BEHAVIOR" => @configuration.deprecated_false_parameter_behavior,
+        "DEPRECATED_NIL_QUERY_PARAMETER_BEHAVIOR" => @configuration.deprecated_nil_query_parameter_behavior,
+        "DEFAULT_URL_OPTIONS" => json(@configuration.default_url_options),
+        "PREFIX" => json(prefix),
+        "SPECIAL_OPTIONS_KEY" => json(@configuration.special_options_key),
+        "SERIALIZER" => @configuration.serializer || json(nil),
+        "MODULE_TYPE" => json(@configuration.module_type),
+        "WRAPPER" => wrapper_variable,
+        "IMPORT_ROUTER" => import_router_variable,
+        "EMBED_ROUTER" => embed_router_variable
       }
     end
 
     sig { returns(String) }
     def embed_router_variable
-      unless @configuration.use_package? || @configuration.modern?
-        read_js(@configuration.router_source_file)
-      else
+      if @configuration.use_package? || @configuration.modern?
         ""
+      else
+        read_js(@configuration.router_source_file)
       end
     end
 
@@ -177,21 +175,21 @@ module JsRoutes
     sig { returns(String) }
     def wrapper_variable
       case @configuration.module_type
-      when 'ESM', 'PKG'
-        'const __jsr = '
-      when 'NIL'
+      when "ESM", "PKG"
+        "const __jsr = "
+      when "NIL"
         namespace = @configuration.namespace
         if namespace
-          if namespace.include?('.')
+          if namespace.include?(".")
             "#{namespace} = "
           else
             "(typeof window !== 'undefined' ? window : this).#{namespace} = "
           end
         else
-          ''
+          ""
         end
       else
-        ''
+        ""
       end
     end
 
@@ -206,7 +204,7 @@ module JsRoutes
       JsRoutes.json(value)
     end
 
-    sig {params(application: Application).returns(T::Array[JourneyRoute])}
+    sig { params(application: Application).returns(T::Array[JourneyRoute]) }
     def routes_from(application)
       T.unsafe(application).routes.named_routes.to_h.values.sort_by(&:name)
     end
@@ -242,7 +240,7 @@ module JsRoutes
 
     sig { returns(String) }
     def export_separator
-      @configuration.dts? ? ': ' : ' = '
+      @configuration.dts? ? ": " : " = "
     end
 
     sig { returns(T::Array[StringArray]) }

--- a/lib/templates/initializer.rb
+++ b/lib/templates/initializer.rb
@@ -27,6 +27,12 @@ JsRoutes.setup do |c|
   #   host: 'example.com', protocol: 'https', format: 'json'
   # }
 
+  # Output location relative to Rails root. Accepts a directory or a full file path:
+  #   directory  → c.file = "app/frontend"          # writes app/frontend/routes.js
+  #   full path  → c.file = "app/frontend/routes.js"
+  # Default: app/javascript/routes.js
+  # c.file = "app/javascript/routes.js"
+
   # More options:
   # @see https://github.com/railsware/js-routes#available-options
 end

--- a/spec/js_routes/generators/middleware_spec.rb
+++ b/spec/js_routes/generators/middleware_spec.rb
@@ -1,9 +1,81 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe JsRoutes::Generators::Middleware do
-
   it "has correct source_root" do
-    expect(JsRoutes::Generators::Middleware.source_root).to eq(gem_root.join('lib/templates').to_s)
+    expect(JsRoutes::Generators::Middleware.source_root).to eq(gem_root.join("lib/templates").to_s)
   end
 
+  describe "#gitignore_content" do
+    subject(:generator) { described_class.new([js_routes_file].compact) }
+
+    context "without custom file" do
+      let(:js_routes_file) { nil }
+
+      it "uses the default JS path" do
+        default_path = JsRoutes::Configuration.new.output_file.to_s
+        expect(generator.send(:gitignore_content)).to include("/#{default_path}")
+      end
+
+      it "includes the default DTS path" do
+        default_path = JsRoutes::Configuration.new.output_file.to_s.sub(/\.js\z/, ".d.ts")
+        expect(generator.send(:gitignore_content)).to include("/#{default_path}")
+      end
+    end
+
+    context "with a custom file path" do
+      let(:js_routes_file) { "app/frontend/routes.js" }
+
+      it "uses the custom JS path" do
+        expect(generator.send(:gitignore_content)).to include("/app/frontend/routes.js")
+      end
+
+      it "derives the DTS path from the custom JS path" do
+        expect(generator.send(:gitignore_content)).to include("/app/frontend/routes.d.ts")
+      end
+
+      it "does not include the default JS path" do
+        expect(generator.send(:gitignore_content)).not_to include("/app/javascript/routes.js")
+      end
+    end
+
+    context "with a directory path" do
+      let(:js_routes_file) { "app/frontend" }
+
+      it "appends routes.js to the directory" do
+        expect(generator.send(:gitignore_content)).to include("/app/frontend/routes.js")
+      end
+
+      it "appends routes.d.ts to the directory" do
+        expect(generator.send(:gitignore_content)).to include("/app/frontend/routes.d.ts")
+      end
+    end
+  end
+
+  describe "output_file with custom path" do
+    it "uses the path as-is when it contains a directory component" do
+      config = JsRoutes::Configuration.new(file: "app/frontend/routes.js")
+      expect(config.output_file.to_s).to eq("app/frontend/routes.js")
+    end
+
+    it "appends routes.js when given a directory" do
+      config = JsRoutes::Configuration.new(file: "app/frontend")
+      expect(config.output_file.to_s).to eq("app/frontend/routes.js")
+    end
+
+    it "appends routes.d.ts when given a directory in DTS mode" do
+      config = JsRoutes::Configuration.new(file: "app/frontend", module_type: "DTS")
+      expect(config.output_file.to_s).to eq("app/frontend/routes.d.ts")
+    end
+
+    it "prepends JS directory for bare filenames" do
+      config = JsRoutes::Configuration.new(file: "custom_routes.js")
+      expect(config.output_file.to_s).to include("custom_routes.js")
+      expect(config.output_file.to_s).not_to eq("custom_routes.js")
+    end
+
+    it "uses default path when file option is nil" do
+      config = JsRoutes::Configuration.new
+      expect(config.output_file.to_s).to include("routes.js")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- The middleware generator now accepts an optional argument for the output location (directory or full file path)
- The `file` config option now accepts a **directory** (e.g. `"app/frontend"`) in addition to a full path — the default filename is appended automatically
- `FileUtils.mkdir_p` added before file writes so the output directory is created automatically if it does not exist

## Usage

```sh
# Default — app/javascript/routes.js
rails generate js_routes:middleware

# Custom directory — creates app/frontend/routes.js + routes.d.ts
rails generate js_routes:middleware app/frontend

# Custom full path
rails generate js_routes:middleware app/frontend/my_routes.js
```

The generator writes `c.file` into the initializer and adds the correct paths to `.gitignore` automatically.

The same directory syntax works in the initializer:

```ruby
JsRoutes.setup do |c|
  c.file = "app/frontend"          # => app/frontend/routes.js
  # or
  c.file = "app/frontend/routes.js"
end
```

## Test plan

- [ ] `rails generate js_routes:middleware` — generates at default path, no `c.file` in initializer
- [ ] `rails generate js_routes:middleware app/frontend` — creates `app/frontend/routes.js` + `.d.ts`, initializer has `c.file = "app/frontend"`, `.gitignore` shows `/app/frontend/routes.js` and `/app/frontend/routes.d.ts`
- [ ] `rails generate js_routes:middleware app/frontend/my_routes.js` — full path variant works end-to-end
- [ ] `rake js:routes` with a non-existent output directory creates the directory automatically
- [ ] 245 RSpec examples pass (1 pre-existing failure in `dts_spec` due to missing `node_modules` in CI env, unrelated to this PR)