### PR TITLE
Avoid empty query separators for Rails-head arrays

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -87,15 +87,27 @@ const Router = (() => {
             };
             return result;
         }
-        default_serializer(value, prefix) {
+        default_serializer(value, prefix, array_element = false) {
             if (!prefix && !this.is_object(value)) {
                 throw new Error("URL parameters should be a javascript hash");
             }
             prefix = prefix || "";
             const result = [];
             if (this.is_array(value)) {
+                // Rails serializes an empty array nested inside another array as a nil
+                // query value, while an empty object contributes no query parameter.
+                if (value.length === 0) {
+                    return array_element
+                        ? this.default_serializer(null, prefix + "[]")
+                        : "";
+                }
                 for (const element of value) {
-                    result.push(this.default_serializer(element, prefix + "[]"));
+                    const subvalue = this.default_serializer(element, prefix + "[]", true);
+                    // Skip empty object results so arrays do not produce leading,
+                    // trailing, or doubled "&" separators.
+                    if (subvalue.length) {
+                        result.push(subvalue);
+                    }
                 }
             }
             else if (this.is_object(value)) {

--- a/lib/router.ts
+++ b/lib/router.ts
@@ -215,15 +215,35 @@ const Router: RouterConstructor = (() => {
       return result as any;
     }
 
-    private default_serializer(value: unknown, prefix?: string | null): string {
+    private default_serializer(
+      value: unknown,
+      prefix?: string | null,
+      array_element = false,
+    ): string {
       if (!prefix && !this.is_object(value)) {
         throw new Error("URL parameters should be a javascript hash");
       }
       prefix = prefix || "";
       const result: string[] = [];
       if (this.is_array(value)) {
+        // Rails serializes an empty array nested inside another array as a nil
+        // query value, while an empty object contributes no query parameter.
+        if (value.length === 0) {
+          return array_element
+            ? this.default_serializer(null, prefix + "[]")
+            : "";
+        }
         for (const element of value) {
-          result.push(this.default_serializer(element, prefix + "[]"));
+          const subvalue = this.default_serializer(
+            element,
+            prefix + "[]",
+            true,
+          );
+          // Skip empty object results so arrays do not produce leading,
+          // trailing, or doubled "&" separators.
+          if (subvalue.length) {
+            result.push(subvalue);
+          }
         }
       } else if (this.is_object(value)) {
         for (let key in value) {

--- a/spec/js_routes/default_serializer_spec.rb
+++ b/spec/js_routes/default_serializer_spec.rb
@@ -13,6 +13,20 @@ describe JsRoutes, "#serialize" do
     evallib(**options)
   end
 
+  def rails_fixed_empty_hash_array_query?
+    ActiveSupport.gem_version >= Gem::Version.new("8.2.0.alpha")
+  end
+
+  def fixed_empty_hash_array_query(value)
+    result = value.to_query
+    return result if rails_fixed_empty_hash_array_query?
+
+    # Rails versions before this fix can emit leading, trailing, or doubled
+    # separators for empty hashes inside arrays. Keep deriving expectations from
+    # to_query, then normalize only that known separator bug.
+    result.gsub(/\A&+|&+\z|(&){2,}/) { $1 ? '&' : '' }
+  end
+
   it "serializes basic object, array, nested object, and empty string values like Rails" do
     expectjs("Routes.serialize({a: 1, b: [2,3], c: {d: 4, e: 5}, f: ''})").to eq(
       {a: 1, b: [2,3], c: {d: 4, e: 5}, f: ''}.to_query
@@ -28,6 +42,36 @@ describe JsRoutes, "#serialize" do
         "Routes.serialize(query);",
       ].join("\n")
     ).to eq({a:1, b:2}.to_query)
+  end
+
+  it "serializes nested empty arrays like Rails" do
+    expectjs("Routes.serialize({a: [[], 1], b: [[[]]]})").to eq(
+      {a: [[], 1], b: [[[]]]}.to_query
+    )
+  end
+
+  it "serializes arrays containing empty objects without empty separators" do
+    expectjs("Routes.serialize({a: [1, {}, 2]})").to eq(
+      fixed_empty_hash_array_query({a: [1, {}, 2]})
+    )
+  end
+
+  it "serializes arrays with leading empty objects without empty separators" do
+    expectjs("Routes.serialize({a: [{}, {c: 1}]})").to eq(
+      fixed_empty_hash_array_query({a: [{}, {c: 1}]})
+    )
+  end
+
+  it "serializes arrays with trailing empty objects without empty separators" do
+    expectjs("Routes.serialize({a: [{c: 1}, {}]})").to eq(
+      fixed_empty_hash_array_query({a: [{c: 1}, {}]})
+    )
+  end
+
+  it "serializes arrays with nested empty objects without empty separators" do
+    expectjs("Routes.serialize({a: [{b: {}}, {d: 1}]})").to eq(
+      fixed_empty_hash_array_query({a: [{b: {}}, {d: 1}]})
+    )
   end
 
   it "omits undefined object properties by default" do
@@ -100,18 +144,14 @@ describe JsRoutes, "#serialize" do
     end
 
     it "serializes array objects with omitted undefined properties without empty separators" do
-      pending("Rails main fixed empty hash array serialization in rails/rails#57500")
-
       expectjs("Routes.serialize({a: [{b: undefined}, {c: 1}]})").to eq(
-        "a%5B%5D%5Bc%5D=1"
+        fixed_empty_hash_array_query({a: [{}, {c: 1}]})
       )
     end
 
     it "serializes mixed arrays with omitted undefined properties without empty separators" do
-      pending("Rails main fixed empty hash array serialization in rails/rails#57500")
-
       expectjs("Routes.serialize({a: [1, {b: undefined}, 2]})").to eq(
-        "a%5B%5D=1&a%5B%5D=2"
+        fixed_empty_hash_array_query({a: [1, {}, 2]})
       )
     end
 
@@ -122,10 +162,8 @@ describe JsRoutes, "#serialize" do
     end
 
     it "serializes nested objects that become empty inside arrays without empty separators" do
-      pending("Rails main fixed empty hash array serialization in rails/rails#57500")
-
       expectjs("Routes.serialize({a: [{b: {c: undefined}}, {d: 1}]})").to eq(
-        "a%5B%5D%5Bd%5D=1"
+        fixed_empty_hash_array_query({a: [{b: {}}, {d: 1}]})
       )
     end
 

--- a/spec/js_routes/options_spec.rb
+++ b/spec/js_routes/options_spec.rb
@@ -48,7 +48,7 @@ describe JsRoutes, "options" do
         }
         Routes.configure({serializer: function(object, prefix) { return s(filter(object), prefix)}});
       JS
-      expectjs(%q(Routes.inboxes_path({a: [{b: 1}, {c: undefined}, {d: null}]}))).to eql("/inboxes?a%5B%5D%5Bb%5D=1&&")
+      expectjs(%q(Routes.inboxes_path({a: [{b: 1}, {c: undefined}, {d: null}]}))).to eql("/inboxes?a%5B%5D%5Bb%5D=1")
     end
 
     context "when specified" do


### PR DESCRIPTION
## Summary

This updates the default serializer to avoid producing malformed query separators when arrays contain values that serialize to an empty query fragment.

Rails fixed the corresponding `Array#to_query` behavior in rails/rails#57500. Before that fix, empty hashes inside arrays can leave leading, trailing, or doubled `&` separators, for example:

```ruby
{a: [1, {}, 2]}.to_query
# older Rails: "a%5B%5D=1&&a%5B%5D=2"
# fixed Rails: "a%5B%5D=1&a%5B%5D=2"
```

js-routes can hit the same shape directly with empty objects, or indirectly when `undefined` properties are omitted and an object becomes empty.

## Changes

- Skip empty serialized array entries so arrays do not produce leading, trailing, or doubled separators.
- Preserve Rails-compatible nested empty-array behavior, where an empty array inside another array serializes as a nil query value.
- Keep serializer expectations based on Rails `to_query`; for Rails versions before the upstream fix, specs normalize only the known separator bug.

## Coverage

Adds/updates coverage for:

- empty objects in the middle, beginning, and end of arrays
- nested empty objects inside arrays
- omitted `undefined` properties that leave empty objects inside arrays
- nested empty arrays, to ensure that behavior is unchanged
- custom serializer filtering that previously produced a trailing `&&`
